### PR TITLE
fix(pruning): match the pruning mask dtype to the weight

### DIFF
--- a/src/coreai_opt/pruning/spec/prune.py
+++ b/src/coreai_opt/pruning/spec/prune.py
@@ -100,8 +100,8 @@ class PruneImplBase(CompressionSimulatorBase):
         """Compute / re-compute the mask if stale, and then apply it to the weight."""
         if self._dirty:
             new_mask = self.compute_mask(weight, self._sparsity, self._pruning_scheme)
-            if self.mask.device != weight.device:
-                self.mask = self.mask.to(weight.device)
+            if self.mask.device != weight.device or self.mask.dtype != weight.dtype:
+                self.mask = self.mask.to(device=weight.device, dtype=weight.dtype)
             if self.mask.shape != new_mask.shape:
                 self.mask.resize_(new_mask.shape)
             self.mask.copy_(new_mask)

--- a/tests/pruning/test_magnitude_pruner.py
+++ b/tests/pruning/test_magnitude_pruner.py
@@ -47,15 +47,19 @@ def linear_100x100_unique() -> nn.Linear:
 class TestMagnitudePruner:
     """Tests for MagnitudePruner end-to-end behavior."""
 
-    def test_default_magnitude_pruner(self) -> None:
-        """MagnitudePruner() with no config uses default 50% sparsity."""
-        model = nn.Linear(100, 50, bias=False)
+    @pytest.mark.parametrize(
+        "dtype", [torch.float32, torch.float16, torch.bfloat16], ids=["fp32", "fp16", "bf16"]
+    )
+    def test_default_magnitude_pruner(self, dtype: torch.dtype) -> None:
+        """MagnitudePruner() with no config uses default 50% sparsity and keeps the weight dtype."""
+        model = nn.Linear(100, 50, bias=False).to(dtype)
         with torch.no_grad():
             model.weight.copy_(torch.arange(1, 5001, dtype=torch.float32).reshape(50, 100))
 
         pruner = MagnitudePruner(model)
-        pruner.prepare((torch.randn(1, 100),))
+        pruner.prepare((torch.randn(1, 100, dtype=dtype),))
 
+        assert model.weight.dtype == dtype
         sparsity = (model.weight == 0).float().mean().item()
         assert sparsity == 0.5
 


### PR DESCRIPTION
`MagnitudePruner` crashes on float16 and bfloat16 models.

The pruning mask buffer is created as float32 and the forward pass only re-cast it to the weight device, never the dtype. Masking a half-precision weight then promotes the result back to float32, so the layer runs with a float32 weight and the next forward fails:

```
RuntimeError: expected m1 and m2 to have the same dtype, but got: c10::Half != float
```

The forward guard now casts the mask to the weight dtype as well as its device. The new test prunes an fp16 and a bf16 `Linear`, then checks the dtype is kept and the target sparsity is reached.
