### PR TITLE
fix(palettization): cluster bfloat16 weights as float32

### DIFF
--- a/src/coreai_opt/palettization/kmeans/kmeans_fake_palettize.py
+++ b/src/coreai_opt/palettization/kmeans/kmeans_fake_palettize.py
@@ -417,6 +417,11 @@ class _KMeansFakePalettize(_FakePalettizeImplBase):
         """
         num_clusters = 2**self.n_bits
 
+        # numpy has no bfloat16 dtype, so cluster bf16 weights as float32. The
+        # centroids are cast back to the weight dtype by the caller.
+        if block_weight.dtype == torch.bfloat16:
+            block_weight = block_weight.float()
+
         block_weight_flatten = block_weight.flatten().numpy()
         if block_sensitivity is not None:
             block_sensitivity_flatten = block_sensitivity.flatten().numpy()

--- a/tests/palettization/test_kmeans_fake_palettize.py
+++ b/tests/palettization/test_kmeans_fake_palettize.py
@@ -63,13 +63,16 @@ def _valid_lut_dtype_qscheme_combinations():
 class Test_KMeansFakePalettize:
     """Test cases for _KMeansFakePalettize class."""
 
+    @pytest.mark.parametrize(
+        "weight_dtype", [torch.float32, torch.float16, torch.bfloat16], ids=["fp32", "fp16", "bf16"]
+    )
     @pytest.mark.parametrize("lut_dtype", [None, *_SUPPORTED_LUT_DTYPES])
-    def test__calculate_centroids_simple_per_tensor(self, lut_dtype):
+    def test__calculate_centroids_simple_per_tensor(self, lut_dtype, weight_dtype):
         """Test _calculate_centroids with simple random weight matrix
         using per-tensor granularity.
         """
         # Create a simple weight matrix with known values for easy verification
-        weight = torch.tensor([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], dtype=torch.float32)
+        weight = torch.tensor([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], dtype=weight_dtype)
 
         # Create palettization spec with 2-bit (4 centroids)
         spec = PalettizationSpec(


### PR DESCRIPTION
`KMeansPalettizer` crashes on bfloat16 weights.

`_cluster_weights_1d` clusters the weight through numpy with `block_weight.flatten().numpy()`. numpy has no bfloat16 dtype, so the call raises a `TypeError`.

```
TypeError: Got unsupported ScalarType BFloat16
```

float16 and float32 weights work. The fix casts a bfloat16 block to float32 before the numpy conversion, matching the vector path which already does `vectorized.float()` in `_cluster_weights_2d`. The centroids are cast back to the weight dtype by the caller, so the LUT and reconstruction stay bfloat16. The existing `test__calculate_centroids_simple_per_tensor` now parametrizes the weight dtype over float32, float16, and bfloat16.
