### PR TITLE
fix(quantization): resolve eager axis defaults for subclassed modules

### DIFF
--- a/src/coreai_opt/quantization/_axis_defaults.py
+++ b/src/coreai_opt/quantization/_axis_defaults.py
@@ -182,6 +182,27 @@ def _collect_weight_fq_entries_graph(model: GraphModule) -> _WeightFQMap:
     return fq_map
 
 
+def _resolve_eager_owner_type(module: nn.Module) -> type[nn.Module]:
+    """Resolve a parametrized module to the base type that carries axis defaults.
+
+    Parametrization replaces a module's class with a synthetic subclass, so
+    ``type(module).__bases__[0]`` unwraps only one level and misses user subclasses
+    such as ``class MyLinear(nn.Linear)``. Walk the MRO and return the first base in
+    the defaults tables, falling back to the immediate base when none matches.
+
+    Args:
+        module (nn.Module): The parametrized module whose owner type to resolve.
+
+    Returns:
+        type[nn.Module]: The first base class with a defaults-table entry, or
+            ``type(module).__bases__[0]`` if none is found.
+    """
+    for base in type(module).__mro__:
+        if base in _PER_CHANNEL_WEIGHT_AXIS_DEFAULTS or base in _PER_BLOCK_WEIGHT_AXIS_DEFAULTS:
+            return base
+    return type(module).__bases__[0]
+
+
 def _collect_weight_fq_entries_eager(model: nn.Module) -> _WeightFQMap:
     """Collect weight fake-quantize entries from an eager-mode model.
 
@@ -205,7 +226,7 @@ def _collect_weight_fq_entries_eager(model: nn.Module) -> _WeightFQMap:
         if not P.is_parametrized(module, "weight"):
             continue
 
-        owner_type = type(module).__bases__[0]
+        owner_type = _resolve_eager_owner_type(module)
 
         for fq in module.parametrizations["weight"]:
             if not isinstance(fq, FakeQuantizeImplBase):

--- a/tests/quantization/test_axis_defaults.py
+++ b/tests/quantization/test_axis_defaults.py
@@ -193,6 +193,26 @@ class TestWeightAxisDefaults:
         assert weight_fqs[0].granularity.axis == expected_axis
 
     @pytest.mark.parametrize("execution_mode", _EXECUTION_MODE_PARAMS)
+    @pytest.mark.parametrize("granularity", _GRANULARITY_NONE_PARAMS)
+    def test_subclass_resolves_to_base_default(self, granularity, execution_mode):
+        """A subclass of a supported module resolves to its base type's default axis."""
+
+        class _CustomLinear(nn.Linear):
+            pass
+
+        config = _make_config(granularity, execution_mode)
+        prepared = Quantizer(_CustomLinear(32, 16), config).prepare((torch.randn(1, 32),))
+
+        if isinstance(granularity, PerChannelGranularity):
+            expected_axis = _PER_CHANNEL_WEIGHT_AXIS_DEFAULTS[nn.Linear]
+        else:
+            expected_axis = _PER_BLOCK_WEIGHT_AXIS_DEFAULTS[nn.Linear]
+
+        weight_fqs = _get_weight_fqs(prepared)
+        assert len(weight_fqs) == 1
+        assert weight_fqs[0].granularity.axis == expected_axis
+
+    @pytest.mark.parametrize("execution_mode", _EXECUTION_MODE_PARAMS)
     @pytest.mark.parametrize("granularity", _GRANULARITY_EXPLICIT_PARAMS)
     def test_explicit_axis_preserved(self, granularity, execution_mode):
         """Explicit axis value is not overridden by the defaults pass."""


### PR DESCRIPTION
Quantizing a subclass of a supported module (`class MyLinear(nn.Linear)`) crashes in eager mode while graph mode handles it.

`_collect_weight_fq_entries_eager` reads the owner type with `type(module).__bases__[0]`. Parametrizing the weight wraps the module in a synthetic subclass, so this unwraps one level to the user class, not the base `nn.Linear`. That class is not in the axis-defaults tables, so `prepare()` raises an unresolved-axis error.

```
ValueError: Weight fake-quantize modules with unresolved axis=None remain after applying defaults
```

Graph mode maps the consuming aten op to `nn.Linear` and resolves it. The fix walks the module MRO and returns the first base with axis defaults, falling back to the immediate base for unsupported modules. The new test prepares a `nn.Linear` subclass in both modes and checks the resolved axes match the defaults.
