### PR TITLE
[CI] Add initial GitHub Actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,99 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+
+  # Stage 1 — initial checks
+  check:
+    name: make check
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - name: Install uv
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        with:
+          enable-cache: false
+      - run: make check
+
+  docs:
+    name: make docs
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - name: Install uv
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        with:
+          enable-cache: false
+      - run: make docs
+
+
+  # Stage 2 — Only runs once every Stage 1 checks are green.
+  ubuntu-tests:
+    name: ubuntu / torch=${{ matrix.torch }} / ${{ matrix.speed }}
+    needs: [check, docs]
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        torch: [lowest, highest]
+        speed: [fast, slow]
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - name: Install uv
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        with:
+          enable-cache: false
+      - name: Run tests
+        run: |
+          if [ "${{ matrix.speed }}" = "slow" ]; then MARKER="slow"; else MARKER="not slow"; fi
+          make test-${{ matrix.torch }}-pytorch PYTEST_ARGS="--marker '$MARKER' --junit"
+      - name: Upload test results
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: test-results-ubuntu-${{ matrix.torch }}-${{ matrix.speed }}
+          path: test-results/
+          if-no-files-found: ignore
+
+  macos-tests:
+    name: macos / torch=highest / ${{ matrix.speed }}
+    needs: [check, docs]
+    if: github.repository_owner == 'apple'
+    runs-on: [self-hosted, macos]
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        speed: [fast, slow]
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - name: Install uv
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        with:
+          enable-cache: false
+      - name: Run tests
+        run: |
+          if [ "${{ matrix.speed }}" = "slow" ]; then MARKER="slow"; else MARKER="not slow"; fi
+          make test-highest-pytorch PYTEST_ARGS="--marker '$MARKER' --junit"
+      - name: Upload test results
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: test-results-macos-highest-${{ matrix.speed }}
+          path: test-results/
+          if-no-files-found: ignore

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -177,6 +177,8 @@ environments = [
     "sys_platform == 'darwin' and platform_machine == 'arm64'",
     "sys_platform == 'linux' and platform_machine == 'x86_64'",
 ]
+exclude-newer = "7 days"
+exclude-newer-package = { coreai-core = false, coreai-torch = false }
 # Declare conflicting groups so uv does not error
 conflicts = [
     [


### PR DESCRIPTION
This PR adds an initial GitHub Actions CI.

This configuration does the following:

1. Stage 1 - Runs fast checks like `make check` and `make docs` on Linux
2. Stage 2 - Runs test suite
	- Lowest PyTorch Slow Tests: Runs on Linux
	- Lowest PyTorch Fast Tests: Runs on Linux
	- Highest PyTorch Slow Tests: Runs on Linux + MacOS
	- Highest PyTorch Fast Tests: Runs on Linux + MacOS

This PR also adds a change in `pyproject.toml` to exclude new packages until they have been on PyPi for more then 7 days. This allows us some security by making sure that the latest wheels are not always being installed.