### PR TITLE
fix(quantization): match the float_range bound dtype to the input

### DIFF
--- a/src/coreai_opt/quantization/spec/qparams_calculator.py
+++ b/src/coreai_opt/quantization/spec/qparams_calculator.py
@@ -152,6 +152,11 @@ class QParamsCalculatorBase(_ClassRegistryMixin, nn.Module):
                 min_val = torch.clamp(computed_min, max=0)
             if max_val is None:
                 max_val = torch.clamp(computed_max, min=0)
+            # A one-sided float_range pairs a float_range bound (built at float32)
+            # with a range-calculator bound at the input dtype. Cast both to the
+            # input dtype so this mixed case has matching dtypes for the qparams op.
+            min_val = min_val.to(tensor.dtype)
+            max_val = max_val.to(tensor.dtype)
         return min_val, max_val
 
     def _compute_e8m0_scale(self, max_abs: torch.Tensor) -> torch.Tensor:

--- a/tests/quantization/test_qparams_calculator.py
+++ b/tests/quantization/test_qparams_calculator.py
@@ -457,6 +457,29 @@ def test_float_range(float_range, granularity):
         assert torch.all(torch.abs(qdq_max - float_range[1]) <= scale)
 
 
+@pytest.mark.parametrize("input_dtype", [torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("float_range", [[None, 10.0], [-10.0, None]])
+def test_float_range_one_sided_half_precision(input_dtype, float_range):
+    """Test a one-sided float_range resolves on float16 and bfloat16 inputs."""
+    qparams_calc = StaticQParamsCalculator(
+        dtype=torch.int8,
+        qscheme=QuantizationScheme.ASYMMETRIC,
+        granularity=PerChannelGranularity(axis=0),
+        target_dtype=torch.int8,
+        quant_min=-128,
+        quant_max=127,
+        range_calculator=MinMaxRangeCalculator(PerChannelGranularity(axis=0)),
+        float_range=float_range,
+    )
+
+    x = (torch.randn(4, 8) * 100.0).to(input_dtype)
+    scale, _, _ = qparams_calc(x)
+
+    # The resolved scale must carry the half-precision input dtype.
+    assert scale.dtype == input_dtype
+    assert torch.all(scale > 0)
+
+
 @pytest.mark.parametrize("float_range", [[0.0, 5.0], [-5.0, 0.0]])
 def test_float_range_with_symmetric(float_range):
     """


### PR DESCRIPTION
`StaticQParamsCalculator` crashes on float16 and bfloat16 inputs when `float_range` fixes only one side.

`_get_min_and_max_val` takes the fixed bound from `float_range` (built by `torch.full`, so float32) and the other bound from the range calculator (the input dtype). With a one-sided range the two disagree on dtype and `choose_qparams_affine_with_min_max` rejects them.

```
AssertionError: Expecting `min_val` and `max_val` to have the same dtype
```

Two-sided and fully dynamic ranges keep matching dtypes and work. The fix casts both bounds to the input dtype once the range is resolved, so the fixed bound matches the computed one. The new test runs a one-sided range on fp16 and bf16 inputs.
