### PR TITLE
fix(palettization): cast bfloat16 sensitivities to float32

### DIFF
--- a/src/coreai_opt/palettization/kmeans/kmeans_fake_palettize.py
+++ b/src/coreai_opt/palettization/kmeans/kmeans_fake_palettize.py
@@ -198,6 +198,10 @@ class _KMeansFakePalettize(_FakePalettizeImplBase):
         # Reshape sensitivities if available
         if self.sensitivities is not None:
             sensitivities = self.sensitivities.cpu()
+            # numpy has no bfloat16 dtype, so cluster bf16 sensitivities as
+            # float32, matching the block-weight handling in _cluster_weights_1d.
+            if sensitivities.dtype == torch.bfloat16:
+                sensitivities = sensitivities.float()
             sensitivities = self.reshape_strategy.reshape_for_kmeans(
                 sensitivities, axis
             )

--- a/tests/palettization/test_kmeans_fake_palettize.py
+++ b/tests/palettization/test_kmeans_fake_palettize.py
@@ -108,6 +108,39 @@ class Test_KMeansFakePalettize:
         print(f"Reconstruction MSE: {mse}")
         assert mse < 0.5
 
+    @pytest.mark.parametrize("cluster_dim", [1, 2])
+    def test__calculate_centroids_bfloat16_sensitivities(self, cluster_dim):
+        """Test _calculate_centroids with bfloat16 sensitivities for the scalar
+        (cluster_dim=1) and vector (cluster_dim > 1) clustering paths.
+        """
+        weight = torch.randn(32, 16, dtype=torch.bfloat16)
+
+        spec = PalettizationSpec(
+            n_bits=2,
+            granularity=PerTensorGranularity(),
+            cluster_dim=cluster_dim,
+        )
+        palettizer = _KMeansFakePalettize(
+            n_bits=spec.n_bits,
+            lut_qspec=spec.lut_qspec,
+            granularity=spec.granularity,
+            cluster_dim=spec.cluster_dim,
+            enable_per_channel_scale=spec.enable_per_channel_scale,
+        )
+        # Positive sensitivities prevent a zero-total-weight cluster from yielding a NaN centroid.
+        palettizer.sensitivities = torch.rand_like(weight) + 1.0
+
+        lut, indices = palettizer._calculate_centroids(weight)
+        assert lut.dtype == weight.dtype
+        assert lut.shape == (1, 1, 2**spec.n_bits, cluster_dim)
+
+        palettized = palettizer._palettize(lut, indices, weight)
+        assert palettized.shape == weight.shape
+        assert palettized.dtype == weight.dtype
+
+        mse = torch.mean((weight.float() - palettized.float()) ** 2)
+        assert mse < 0.5
+
     def test_cluster_weights_1d_with_few_unique_values(self):
         """Test _cluster_weights_1d when there are fewer unique values than clusters."""
         # Create weight with only 2 unique values but request 4 clusters


### PR DESCRIPTION
`KMeansPalettizer` crashes on bfloat16 models when sensitivity-based palettization is used.

`calibration_mode` builds gradient sensitivities that inherit the model dtype. `_calculate_centroids` casts the weight to float32 before clustering through numpy but leaves the sensitivities in bfloat16, so the scalar path `block_sensitivity.flatten().numpy()` and the vector path in `_efficient_kmeans` raise a `TypeError`.

```
TypeError: Got unsupported ScalarType BFloat16
```

float16 and float32 sensitivities work. The fix casts bfloat16 sensitivities to float32 before the numpy conversion, matching the existing weight cast. Sensitivities only weight the k-means, so the LUT and reconstruction stay bfloat16. The new test runs `_calculate_centroids` with bfloat16 sensitivities over the scalar and vector cluster_dim paths.
