### PR TITLE
ci: Add Initial CI pipelines

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,50 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+
+  check:
+    name: make check
+    if: github.repository == 'apple/coreai-optimization'
+    runs-on: [self-hosted, macos, tahoe, ARM64]
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - name: Install uv
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        with:
+          enable-cache: false
+      - run: make check
+
+  macos-tests:
+    name: macos / torch=highest / fast
+    needs: [check]
+    if: github.repository == 'apple/coreai-optimization'
+    runs-on: [self-hosted, macos, tahoe, ARM64]
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - name: Install uv
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        with:
+          enable-cache: false
+      - name: Run tests
+        run: make test-highest-pytorch PYTEST_ARGS="--marker 'not slow' --junit"
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: test-results-macos-highest-fast
+          path: test-results/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -177,6 +177,8 @@ environments = [
     "sys_platform == 'darwin' and platform_machine == 'arm64'",
     "sys_platform == 'linux' and platform_machine == 'x86_64'",
 ]
+exclude-newer = "7 days"
+exclude-newer-package = { coreai-core = false, coreai-torch = false }
 # Declare conflicting groups so uv does not error
 conflicts = [
     [


### PR DESCRIPTION
This PR adds an initial GitHub Actions CI.

This configuration does the following:

1. Stage 1 - Runs `make check` on MacOS
2. Stage 2 - Runs test suite
	- Highest PyTorch Fast Tests: Runs on MacOS

This PR also adds a change in `pyproject.toml` to exclude new packages until they have been on PyPi for more then 7 days. This allows us some security by making sure that the latest wheels are not always being installed.