### PR TITLE
ci: Add initial CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,6 +22,8 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          fetch-depth: 0
       - name: Install uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,7 +34,8 @@ jobs:
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
           enable-cache: false
-      - run: make check
+      - name: Run `make check`
+        run: make check
 
   macos-tests:
     name: macOS / make test-highest-pytorch / markers=not-slow
@@ -49,7 +50,7 @@ jobs:
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
           enable-cache: false
-      - name: Run tests
+      - name: Run `make test-highest-pytorch`
         run: make test-highest-pytorch PYTEST_ARGS="--marker 'not slow' --junit"
       - name: Upload test results
         if: always()

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,7 +21,7 @@ concurrency:
 jobs:
 
   check:
-    name: make check
+    name: macOS / make check
     if: github.repository == 'apple/coreai-optimization'
     runs-on: [self-hosted, macos, tahoe, ARM64]
     timeout-minutes: 30
@@ -36,7 +36,7 @@ jobs:
       - run: make check
 
   macos-tests:
-    name: macos / torch=highest / fast
+    name: macOS / make test-highest-pytorch / markers=not-slow
     needs: [check]
     if: github.repository == 'apple/coreai-optimization'
     runs-on: [self-hosted, macos, tahoe, ARM64]

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,50 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+
+  check:
+    name: make check
+    if: github.repository == 'apple/coreai-optimization'
+    runs-on: [self-hosted, macos, tahoe, ARM64]
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - name: Install uv
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        with:
+          enable-cache: false
+      - run: make check
+
+  macos-tests:
+    name: macos / torch=highest / fast
+    needs: [check]
+    if: github.repository == 'apple/coreai-optimization'
+    runs-on: [self-hosted, macos, tahoe, ARM64]
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - name: Install uv
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        with:
+          enable-cache: false
+      - name: Run tests
+        run: make test-highest-pytorch PYTEST_ARGS="--marker 'not slow' --junit"
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: test-results-macos-highest-fast
+          path: test-results/

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,7 +26,8 @@ jobs:
     runs-on: [self-hosted, macos, tahoe, ARM64]
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - name: Check out repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
       - name: Install uv
@@ -42,7 +43,8 @@ jobs:
     runs-on: [self-hosted, macos, tahoe, ARM64]
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - name: Check out repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Install uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,5 +1,10 @@
 name: CI
 
+run-name: >-
+  ${{ github.event_name == 'pull_request'
+  && format('CI · PR #{0} · {1} · @{2}', github.event.pull_request.number, github.event.pull_request.head.ref, github.actor)
+  || format('CI · push {0} · @{1}', github.ref_name, github.actor) }}
+
 on:
   pull_request:
     branches: [main]

--- a/configs/darker.toml
+++ b/configs/darker.toml
@@ -5,5 +5,5 @@ formatter = "ruff"
 # We concluded that 88 is too restrictive for some use cases, so we use 100
 # Darker should override tool.ruff, but does not
 line-length = 100
-revision = "main"
+revision = "origin/main..."
 target-version = "py311"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -177,6 +177,8 @@ environments = [
     "sys_platform == 'darwin' and platform_machine == 'arm64'",
     "sys_platform == 'linux' and platform_machine == 'x86_64'",
 ]
+exclude-newer = "7 days"
+exclude-newer-package = { coreai-core = false, coreai-torch = false }
 # Declare conflicting groups so uv does not error
 conflicts = [
     [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -177,6 +177,9 @@ environments = [
     "sys_platform == 'darwin' and platform_machine == 'arm64'",
     "sys_platform == 'linux' and platform_machine == 'x86_64'",
 ]
+# Security: only install distributions on PyPI for at least 7 days, giving
+# malicious uploads time to be detected and yanked before they reach CI.
+# coreai-core/coreai-torch are exempted (false) so CI tests their latest releases.
 exclude-newer = "7 days"
 exclude-newer-package = { coreai-core = false, coreai-torch = false }
 # Declare conflicting groups so uv does not error

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 build-backend = "setuptools.build_meta"
-requires = [ "setuptools>=42", "wheel" ]
+requires = [ "setuptools>=42" ]
 
 [project]
 name = "coreai-opt"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -177,10 +177,10 @@ environments = [
     "sys_platform == 'darwin' and platform_machine == 'arm64'",
     "sys_platform == 'linux' and platform_machine == 'x86_64'",
 ]
-# Security: only install distributions on PyPI for at least 7 days, giving
+# Security: only install distributions on PyPI for at least 3 days, giving
 # malicious uploads time to be detected and yanked before they reach CI.
 # coreai-core/coreai-torch are exempted (false) so CI tests their latest releases.
-exclude-newer = "7 days"
+exclude-newer = "3 days"
 exclude-newer-package = { coreai-core = false, coreai-torch = false }
 # Declare conflicting groups so uv does not error
 conflicts = [


### PR DESCRIPTION
This PR adds an initial GitHub Actions CI.

This configuration does the following:

1. Stage 1 - Runs `make check` on MacOS
2. Stage 2 - Runs test suite
	- Highest PyTorch Fast Tests: Runs on MacOS

This PR also adds a change in `pyproject.toml` to exclude new packages until they have been on PyPi for more then 7 days. This allows us some security by making sure that the latest wheels are not always being installed.