### PR TITLE
ci: add dependabot yaml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "ci"
+    groups:
+      actions:
+        patterns:
+          - "*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 3
     commit-message:
       prefix: "ci"
     groups:


### PR DESCRIPTION
Adds dependabot configuration for GitHub Actions as recommended by @madrob [here](https://github.com/apple/coreai-optimization/pull/9#issuecomment-4783566332)

Every week on Monday, `dependabot` will create a PR that will update the SHAs that are used for github actions (like checkout, etc.). Then, a `coreai-opt` maintainer will allow the CI to run based on `dependabot`'s changes and we see that the CI result. Based on that, we can merge the PR or investigate.

Similar to `pyproject.toml`, we also exclude SHAs that are newer than 3 days.

This ensures that we stay on the latest versions of GitHub Actions SHAs and get the latest security patches