### PR TITLE
Use weights_only=True when loading sensitivities (#16)

### DIFF
--- a/src/coreai_opt/palettization/kmeans/palettizer.py
+++ b/src/coreai_opt/palettization/kmeans/palettizer.py
@@ -204,7 +204,7 @@ class KMeansPalettizer(_BasePalettizer, _EagerCompressionComponentBuilderMixin):
                 f"Loading precomputed sensitivities from {sensitivity_path} "
                 "for weighted k-means clustering"
             )
-            sensitivities = torch.load(sensitivity_path)
+            sensitivities = torch.load(sensitivity_path, weights_only=True)
             self._set_sensitivities_in_fake_palettize_modules(sensitivities)
 
         self._model.apply(_enable_observer)


### PR DESCRIPTION
Fixes #16

`KMeansPalettizer.prepare` loaded `sensitivity_path` via `torch.load` without `weights_only=True`, unlike the checkpoint load path which already uses it. Since `torch.load` defaults to pickle, an untrusted/shared sensitivity file could execute arbitrary code on load (CWE-502). Sensitivities are only `dict[str, torch.Tensor]`, so `weights_only=True` is fully backward compatible.