### PR TITLE
ci: add `ubuntu-latest` test pipelines

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -114,7 +114,7 @@ jobs:
     name: Linux / make test-highest-pytorch / markers=not-slow
     needs: [check, test-smoke, test-tutorials]
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 120
     steps:
       - name: Check out repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -156,7 +156,7 @@ jobs:
     name: Linux / make test-lowest-pytorch / markers=not-slow
     needs: [check, test-smoke, test-tutorials]
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 120
     steps:
       - name: Check out repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,10 +20,11 @@ concurrency:
 
 jobs:
 
+  # ── Stage 1: cheap correctness gate (ubuntu-latest, ungated). ──
+  # Stage 2 runs only if all three of these pass.
   check:
-    name: macOS / make check
-    if: github.repository == 'apple/coreai-optimization'
-    runs-on: [self-hosted, macos, tahoe, ARM64]
+    name: Linux / make check
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
       - name: Check out repository
@@ -37,9 +38,38 @@ jobs:
       - name: Run `make check`
         run: make check
 
+  test-smoke:
+    name: Linux / make test-smoke
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - name: Install uv
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        with:
+          enable-cache: false
+      - name: Run `make test-smoke`
+        run: make test-smoke
+
+  test-tutorials:
+    name: Linux / make test-tutorials
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - name: Install uv
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        with:
+          enable-cache: false
+      - name: Run `make test-tutorials`
+        run: make test-tutorials
+
+  # ── Stage 2: full test matrix, gated on Stage 1. ──
   macos-tests:
     name: macOS / make test-highest-pytorch / markers=not-slow
-    needs: [check]
+    needs: [check, test-smoke, test-tutorials]
     if: github.repository == 'apple/coreai-optimization'
     runs-on: [self-hosted, macos, tahoe, ARM64]
     timeout-minutes: 60
@@ -61,6 +91,7 @@ jobs:
 
   linux-highest-slow:
     name: Linux / make test-highest-pytorch / markers=slow
+    needs: [check, test-smoke, test-tutorials]
     runs-on: ubuntu-latest
     timeout-minutes: 120
     steps:
@@ -81,6 +112,7 @@ jobs:
 
   linux-highest-fast:
     name: Linux / make test-highest-pytorch / markers=not-slow
+    needs: [check, test-smoke, test-tutorials]
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
@@ -101,6 +133,7 @@ jobs:
 
   linux-lowest-slow:
     name: Linux / make test-lowest-pytorch / markers=slow
+    needs: [check, test-smoke, test-tutorials]
     runs-on: ubuntu-latest
     timeout-minutes: 120
     steps:
@@ -121,6 +154,7 @@ jobs:
 
   linux-lowest-fast:
     name: Linux / make test-lowest-pytorch / markers=not-slow
+    needs: [check, test-smoke, test-tutorials]
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -58,3 +58,83 @@ jobs:
         with:
           name: test-results-macos-highest-fast
           path: test-results/
+
+  linux-highest-slow:
+    name: Linux / make test-highest-pytorch / markers=slow
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - name: Install uv
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        with:
+          enable-cache: false
+      - name: Run `make test-highest-pytorch`
+        run: make test-highest-pytorch PYTEST_ARGS="--marker slow --junit"
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: test-results-linux-highest-slow
+          path: test-results/
+
+  linux-highest-fast:
+    name: Linux / make test-highest-pytorch / markers=not-slow
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - name: Install uv
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        with:
+          enable-cache: false
+      - name: Run `make test-highest-pytorch`
+        run: make test-highest-pytorch PYTEST_ARGS="--marker 'not slow' --junit"
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: test-results-linux-highest-fast
+          path: test-results/
+
+  linux-lowest-slow:
+    name: Linux / make test-lowest-pytorch / markers=slow
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - name: Install uv
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        with:
+          enable-cache: false
+      - name: Run `make test-lowest-pytorch`
+        run: make test-lowest-pytorch PYTEST_ARGS="--marker slow --junit"
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: test-results-linux-lowest-slow
+          path: test-results/
+
+  linux-lowest-fast:
+    name: Linux / make test-lowest-pytorch / markers=not-slow
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - name: Install uv
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        with:
+          enable-cache: false
+      - name: Run `make test-lowest-pytorch`
+        run: make test-lowest-pytorch PYTEST_ARGS="--marker 'not slow' --junit"
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: test-results-linux-lowest-fast
+          path: test-results/

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,6 +42,8 @@ jobs:
     name: Linux / make test-smoke
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    env:
+      INSTALL_PRECOMMIT: "false"
     steps:
       - name: Check out repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -56,6 +58,8 @@ jobs:
     name: Linux / make test-tutorials
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    env:
+      INSTALL_PRECOMMIT: "false"
     steps:
       - name: Check out repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -73,6 +77,8 @@ jobs:
     if: github.repository == 'apple/coreai-optimization'
     runs-on: [self-hosted, macos, tahoe, ARM64]
     timeout-minutes: 60
+    env:
+      INSTALL_PRECOMMIT: "false"
     steps:
       - name: Check out repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -94,6 +100,8 @@ jobs:
     needs: [check, test-smoke, test-tutorials]
     runs-on: ubuntu-latest
     timeout-minutes: 120
+    env:
+      INSTALL_PRECOMMIT: "false"
     steps:
       - name: Check out repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -115,6 +123,8 @@ jobs:
     needs: [check, test-smoke, test-tutorials]
     runs-on: ubuntu-latest
     timeout-minutes: 120
+    env:
+      INSTALL_PRECOMMIT: "false"
     steps:
       - name: Check out repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -136,6 +146,8 @@ jobs:
     needs: [check, test-smoke, test-tutorials]
     runs-on: ubuntu-latest
     timeout-minutes: 120
+    env:
+      INSTALL_PRECOMMIT: "false"
     steps:
       - name: Check out repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -157,6 +169,8 @@ jobs:
     needs: [check, test-smoke, test-tutorials]
     runs-on: ubuntu-latest
     timeout-minutes: 120
+    env:
+      INSTALL_PRECOMMIT: "false"
     steps:
       - name: Check out repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,7 +21,6 @@ concurrency:
 jobs:
 
   # ── Stage 1: cheap correctness gate (ubuntu-latest, ungated). ──
-  # Stage 2 runs only if all three of these pass.
   check:
     name: Linux / make check
     runs-on: ubuntu-latest
@@ -95,13 +94,18 @@ jobs:
           name: test-results-macos-highest-fast
           path: test-results/
 
-  linux-highest-slow:
-    name: Linux / make test-highest-pytorch / markers=slow
+  linux-tests:
+    name: Linux / make test-${{ matrix.torch }}-pytorch / markers=${{ matrix.speed == 'slow' && 'slow' || 'not-slow' }}
     needs: [check, test-smoke, test-tutorials]
     runs-on: ubuntu-latest
     timeout-minutes: 120
     env:
       INSTALL_PRECOMMIT: "false"
+    strategy:
+      fail-fast: false
+      matrix:
+        torch: [highest, lowest]
+        speed: [slow, fast]
     steps:
       - name: Check out repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -109,80 +113,11 @@ jobs:
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
           enable-cache: false
-      - name: Run `make test-highest-pytorch`
-        run: make test-highest-pytorch PYTEST_ARGS="--marker slow --junit"
+      - name: Run `make test-${{ matrix.torch }}-pytorch`
+        run: make test-${{ matrix.torch }}-pytorch PYTEST_ARGS="--marker '${{ matrix.speed == 'slow' && 'slow' || 'not slow' }}' --junit"
       - name: Upload test results
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: test-results-linux-highest-slow
-          path: test-results/
-
-  linux-highest-fast:
-    name: Linux / make test-highest-pytorch / markers=not-slow
-    needs: [check, test-smoke, test-tutorials]
-    runs-on: ubuntu-latest
-    timeout-minutes: 120
-    env:
-      INSTALL_PRECOMMIT: "false"
-    steps:
-      - name: Check out repository
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-      - name: Install uv
-        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
-        with:
-          enable-cache: false
-      - name: Run `make test-highest-pytorch`
-        run: make test-highest-pytorch PYTEST_ARGS="--marker 'not slow' --junit"
-      - name: Upload test results
-        if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: test-results-linux-highest-fast
-          path: test-results/
-
-  linux-lowest-slow:
-    name: Linux / make test-lowest-pytorch / markers=slow
-    needs: [check, test-smoke, test-tutorials]
-    runs-on: ubuntu-latest
-    timeout-minutes: 120
-    env:
-      INSTALL_PRECOMMIT: "false"
-    steps:
-      - name: Check out repository
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-      - name: Install uv
-        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
-        with:
-          enable-cache: false
-      - name: Run `make test-lowest-pytorch`
-        run: make test-lowest-pytorch PYTEST_ARGS="--marker slow --junit"
-      - name: Upload test results
-        if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: test-results-linux-lowest-slow
-          path: test-results/
-
-  linux-lowest-fast:
-    name: Linux / make test-lowest-pytorch / markers=not-slow
-    needs: [check, test-smoke, test-tutorials]
-    runs-on: ubuntu-latest
-    timeout-minutes: 120
-    env:
-      INSTALL_PRECOMMIT: "false"
-    steps:
-      - name: Check out repository
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-      - name: Install uv
-        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
-        with:
-          enable-cache: false
-      - name: Run `make test-lowest-pytorch`
-        run: make test-lowest-pytorch PYTEST_ARGS="--marker 'not slow' --junit"
-      - name: Upload test results
-        if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: test-results-linux-lowest-fast
+          name: test-results-linux-${{ matrix.torch }}-${{ matrix.speed }}
           path: test-results/

--- a/scripts/make/install_pre_commit_hooks.sh
+++ b/scripts/make/install_pre_commit_hooks.sh
@@ -60,5 +60,9 @@ if ! command -v lychee &>/dev/null; then
 fi
 
 # Configure git hooks. Force-install so the shebang points to the current venv.
-uv run --no-sync --active pre-commit install -f
-echo "✓ Pre-commit hooks configured to use $VIRTUAL_ENV"
+if [[ "${INSTALL_PRECOMMIT:-true}" == "false" ]]; then
+    echo "Skipping git hook configuration (INSTALL_PRECOMMIT=$INSTALL_PRECOMMIT)"
+else
+    uv run --no-sync --active pre-commit install -f
+    echo "✓ Pre-commit hooks configured to use $VIRTUAL_ENV"
+fi

--- a/scripts/make/setup_env.sh
+++ b/scripts/make/setup_env.sh
@@ -195,6 +195,12 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
+if [[ "$ENSURE_MODE" == true ]]; then
+    INSTALL_PRECOMMIT="${INSTALL_PRECOMMIT:-false}"
+else
+    INSTALL_PRECOMMIT="${INSTALL_PRECOMMIT:-true}"
+fi
+
 # Validate required arguments
 if [[ -z "$PYTHON_VERSION" ]]; then
     echo "Error: --python-version is required"
@@ -339,11 +345,11 @@ echo "Running: ${SYNC_CMD[*]}"
 "${SYNC_CMD[@]}"
 
 echo ""
-echo "[3/3] Configuring pre-commit hooks..."
+echo "[3/3] Installing hook dependencies and configuring pre-commit hooks..."
 if [[ "$VENV_PREEXISTED" == "true" ]]; then
     echo "Skipped (venv already exists, hooks already configured)"
 else
-    "$SCRIPTS_DIR/make/install_pre_commit_hooks.sh" "$COREAI_OPT_HOME"
+    INSTALL_PRECOMMIT="$INSTALL_PRECOMMIT" "$SCRIPTS_DIR/make/install_pre_commit_hooks.sh" "$COREAI_OPT_HOME"
 fi
 
 echo ""

--- a/tests/export/test_graph_mode_mlir_export.py
+++ b/tests/export/test_graph_mode_mlir_export.py
@@ -211,6 +211,7 @@ def test_mnist_export(
         "[Export Tests] ResNet50 graph-mode int8 quantization"
         " SNR falls below threshold on Linux (19.44 < 20.0)"
     ),
+    strict=False,
 )
 def test_resnet_export(
     resnet50_model: torch.nn.Module,


### PR DESCRIPTION
Adds new Linux CI pipelines for the following:
1. `make test-smoke`
2. `make test-tutorials`
3. All 4 highest/lowest + slow/fast test pipelines

The following CI pipelines were edited:
1. `make check` now runs on Linux