### PR TITLE
refactor: remove coremltools as required dependency and introduce `numba` kmeans1d

### DIFF
--- a/changelog.d/27.changed
+++ b/changelog.d/27.changed
@@ -1,0 +1,1 @@
+Replace the coremltools-based 1D k-means used by palettization with a built-in Numba implementation. `coremltools` is no longer a runtime dependency (it is now an optional dependency, installable via the `coreml` extra).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ classifiers = [
 ]
 dynamic = [ "version" ]
 dependencies = [
-    "coremltools>=8.3",
+    "numba>=0.62.0",
     "numpy>=2,<2.4",              # TODO: Remove once coremltools has released a version > 9.0
     "pydantic>=2.0.0",
     "rich>=13.0.0",
@@ -74,6 +74,7 @@ dev = [
     { include-group = "torchvision" },
 ]
 test = [
+    "coremltools>=8.3",    # Needed for the Numba kmeans1d equivalence tests.
     "junitparser>=4.0.2",
     "pytest>=9.0.0",
     "pytest-cov>=4.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,6 @@ classifiers = [
 dynamic = [ "version" ]
 dependencies = [
     "numba>=0.62.0",
-    "numpy>=2,<2.4",              # TODO: Remove once coremltools has released a version > 9.0
     "pydantic>=2.0.0",
     "rich>=13.0.0",
     "safetensors>=0.5.3,<=0.7.0",
@@ -54,6 +53,10 @@ coreai = [
     "coreai-torch==0.4.1",
     "scikit-learn>=1.7.2",
 ]
+coreml = [
+    "coremltools>=8.3",
+    "numpy>=2,<2.4",    # TODO: Remove once coremltools has released a version > 9.0
+]
 [project.urls]
 Changelog = "https://github.com/apple/coreai-optimization/blob/main/CHANGELOG.md"
 Repository = "https://github.com/apple/coreai-optimization"
@@ -74,7 +77,6 @@ dev = [
     { include-group = "torchvision" },
 ]
 test = [
-    "coremltools>=8.3",    # Needed for the Numba kmeans1d equivalence tests.
     "junitparser>=4.0.2",
     "pytest>=9.0.0",
     "pytest-cov>=4.0.0",
@@ -91,12 +93,15 @@ docs = [
     "sphinx-llm==0.3.0",
     "sphinxcontrib-mermaid==1.0.0",
     { include-group = "coreai" },
+    { include-group = "coreml" },
 ]
 # `coreai` group mirrors the `coreai` optional-dependency (extra) so `uv sync`
 # installs CoreAI by default (see tool.uv.default-groups). The extra is the
 # single source of truth; this group self-references it to avoid duplicating the
 # package list.
+# This applies to the `coreml` group as well.
 coreai = [ "coreai-opt[coreai]" ]
+coreml = [ "coreai-opt[coreml]" ]
 # Used in CI to force latest mimimum supported torch version
 # These torch versions must be in bounds of torch versions listed in project dependencies
 highest_tested_torch = [
@@ -146,6 +151,7 @@ tutorial = [
     "papermill>=2.7.0",
     "torchinfo>=1.8.0",
     { include-group = "coreai" },
+    { include-group = "coreml" },
     { include-group = "torchvision" },
 ]
 
@@ -161,7 +167,7 @@ find.where = [ "src" ]
 
 # make env group installed by default with uv sync
 [tool.uv]
-default-groups = [ "dev", "coreai" ]
+default-groups = [ "dev", "coreai", "coreml" ]
 index = [
     { explicit = true, name = "pytorch-cpu", url = "https://download.pytorch.org/whl/cpu" },
     { explicit = true, name = "pytorch-cu128", url = "https://download.pytorch.org/whl/cu128" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dynamic = [ "version" ]
 dependencies = [
     "numba>=0.62.0",
     "pydantic>=2.0.0",
+    "pyyaml>=6.0",
     "rich>=13.0.0",
     "safetensors>=0.5.3,<=0.7.0",
     # PyTorch >= 2.9.0 requires torchao >= 0.15.0

--- a/src/coreai_opt/_utils/_kmeans1d.py
+++ b/src/coreai_opt/_utils/_kmeans1d.py
@@ -1,0 +1,282 @@
+# Copyright 2026 Apple Inc.
+#
+# Use of this source code is governed by a BSD-3-Clause license that can
+# be found in the LICENSE file or at https://opensource.org/licenses/BSD-3-Clause
+
+"""Pure-Python + Numba implementation of globally-optimal 1D k-means.
+
+This is a faithful port of the C++ ``kmeans1d`` extension bundled with
+coremltools (``coremltools._deps._kmeans1d``), itself an implementation of the
+dynamic-programming + SMAWK algorithm of Grønlund et al. (2017),
+https://cs.au.dk/~larsen/papers/1dkmeans.pdf, running in ``O(n log n + kn)``
+time and ``O(kn)`` space.
+
+It computes the same clustering as coremltools (centroids match to a tight
+numerical tolerance) without depending on a compiled extension, keeping the
+package platform-agnostic; Numba JIT-compiles the kernels at runtime. The
+optional ``weights`` argument provides weighted (sensitive) k-means: it
+minimizes ``sum_i w_i * (x_i - mu_c(i))**2``.
+
+The unweighted and weighted paths share one kernel: unweighted clustering is
+the weighted kernel with every weight set to ``1.0`` (the prefix sums then hold
+counts, weighted means reduce to plain means, and the arithmetic is identical).
+
+Equivalence with coremltools (to a tight tolerance) is pinned by
+``tests/test_utils/test_kmeans1d.py``; the comments below that reference the C++
+arithmetic describe *why* the port reproduces it, and those tests are the
+executable proof.
+
+Example:
+    >>> result = cluster([0.0, 0.1, 9.0, 9.1], 2)
+    >>> result.centroids
+    array([0.05, 9.05])
+"""
+
+from __future__ import annotations
+
+from collections import namedtuple
+from collections.abc import Sequence
+
+import numpy as np
+from numba import njit
+
+Clustered = namedtuple("Clustered", ["clusters", "centroids"])
+
+
+@njit(cache=True)
+def _cost(cumw, cumsum, cumsum2, lo, hi):
+    """Weighted within-cluster sum of squared deviations over sorted ``[lo, hi]``."""
+    if hi < lo:
+        return 0.0
+    total_weight = cumw[hi + 1] - cumw[lo]
+    weighted_sum = cumsum[hi + 1] - cumsum[lo]
+    mu = weighted_sum / total_weight
+    # Expanded as sum(w*x^2) + W*mu^2 - 2*mu*sum(w*x); this algebraic form and
+    # statement order reproduce coremltools' float64 result to a tight tolerance.
+    result = cumsum2[hi + 1] - cumsum2[lo]
+    result += total_weight * (mu * mu)
+    result -= (2.0 * mu) * weighted_sum
+    return result
+
+
+@njit(cache=True)
+def _matrix_value(row, col_candidate, prev_costs, cumw, cumsum, cumsum2):
+    """Entry ``(row, col_candidate)`` of the totally-monotone DP cost matrix."""
+    # ``min(row, col_candidate - 1)`` with the C++ unsigned wrap special-cased:
+    # when ``col_candidate == 0`` the C++ ``j - 1`` wraps to a huge value, so the
+    # minimum is ``row``. Padding (col_candidate > row) yields ``prev_costs[row]``,
+    # which is what makes the matrix totally monotone for SMAWK.
+    if col_candidate == 0:
+        prefix_col = row
+    else:
+        prefix_col = col_candidate - 1
+        if row < prefix_col:
+            prefix_col = row
+    return prev_costs[prefix_col] + _cost(cumw, cumsum, cumsum2, col_candidate, row)
+
+
+@njit(cache=True)
+def _smawk(rows, cols, prev_costs, cumw, cumsum, cumsum2, result):
+    """Write ``result[row] = argmin_col matrix_value(row, col)`` for each row.
+
+    Implements the SMAWK algorithm on the implicitly-defined, totally-monotone
+    matrix, in ``O(num_rows + num_cols)`` per level. Tie-breaking follows
+    coremltools (leftmost minimizing column wins) so the recovered cluster
+    boundaries match.
+    """
+    num_rows = rows.shape[0]
+    if num_rows == 0:
+        return
+    num_cols = cols.shape[0]
+
+    # REDUCE: discard columns that can never hold a row minimum. ``>=`` keeps the
+    # incumbent (smaller) column on ties, giving the leftmost argmin.
+    stack = np.empty(num_rows, np.int64)
+    top = 0
+    for ci in range(num_cols):
+        col = cols[ci]
+        while top > 0:
+            row = rows[top - 1]
+            incumbent = stack[top - 1]
+            if _matrix_value(row, col, prev_costs, cumw, cumsum, cumsum2) >= _matrix_value(
+                row, incumbent, prev_costs, cumw, cumsum, cumsum2
+            ):
+                break
+            top -= 1
+        if top < num_rows:
+            stack[top] = col
+            top += 1
+    surviving = stack[:top]
+
+    # Recurse on the odd-indexed rows.
+    num_odd = num_rows // 2
+    odd_rows = np.empty(num_odd, np.int64)
+    for i in range(num_odd):
+        odd_rows[i] = rows[2 * i + 1]
+    _smawk(odd_rows, surviving, prev_costs, cumw, cumsum, cumsum2, result)
+
+    # INTERPOLATE: fill even-indexed rows; each search is bounded on the right by
+    # the already-computed odd neighbor's argmin. Strict ``<`` keeps the leftmost.
+    start = 0
+    row_idx = 0
+    while row_idx < num_rows:
+        row = rows[row_idx]
+        stop = top - 1
+        if row_idx < num_rows - 1:
+            stop = np.searchsorted(surviving, result[rows[row_idx + 1]])
+        argmin = surviving[start]
+        best = _matrix_value(row, argmin, prev_costs, cumw, cumsum, cumsum2)
+        col_idx = start + 1
+        while col_idx <= stop:
+            value = _matrix_value(row, surviving[col_idx], prev_costs, cumw, cumsum, cumsum2)
+            if value < best:
+                argmin = surviving[col_idx]
+                best = value
+            col_idx += 1
+        result[row] = argmin
+        start = stop
+        row_idx += 2
+
+
+@njit(cache=True)
+def _build_prefix_sums(sorted_array, sorted_weights):
+    """Prefix sums (leading zero) of weight, weight*value, and weight*value^2."""
+    n = sorted_array.shape[0]
+    cumw = np.empty(n + 1)
+    cumsum = np.empty(n + 1)
+    cumsum2 = np.empty(n + 1)
+    cumw[0] = 0.0
+    cumsum[0] = 0.0
+    cumsum2[0] = 0.0
+    for i in range(n):
+        w = sorted_weights[i]
+        x = sorted_array[i]
+        cumw[i + 1] = w + cumw[i]
+        cumsum[i + 1] = w * x + cumsum[i]
+        cumsum2[i + 1] = w * x * x + cumsum2[i]
+    return cumw, cumsum, cumsum2
+
+
+@njit(cache=True)
+def _backtrack(boundary, cumw, sorted_array, k):
+    """Recover sorted labels and centroids from the filled DP boundary table.
+
+    Walks the cluster boundaries right-to-left. The centroid is an online
+    (Welford) weighted mean rather than the closed form, which reproduces
+    coremltools' float64 rounding to a tight tolerance.
+    """
+    n = sorted_array.shape[0]
+    sorted_clusters = np.empty(n, np.int64)
+    # Zero-fill matters: when the optimum needs fewer than k clusters, the loop
+    # terminates with leading levels unwritten. coremltools' ctypes centroid
+    # buffer is zero-filled, so those slots come back as 0.0 -- match that.
+    centroids = np.zeros(k)
+    right = n
+    level = k - 1
+    end = n - 1
+    while True:
+        prev_right = right
+        right = boundary[level, end]
+        centroid = 0.0
+        for i in range(right, prev_right):
+            sorted_clusters[i] = level
+            point_weight = cumw[i + 1] - cumw[i]
+            cumulative_weight = cumw[i + 1] - cumw[right]
+            centroid += (sorted_array[i] - centroid) * point_weight / cumulative_weight
+        centroids[level] = centroid
+        if right <= 0:
+            break
+        level -= 1
+        end = right - 1
+
+    return sorted_clusters, centroids
+
+
+@njit(cache=True)
+def _cluster_sorted(sorted_array, sorted_weights, k):
+    """Run DP + SMAWK on already-sorted values/weights, returning sorted labels."""
+    n = sorted_array.shape[0]
+    cumw, cumsum, cumsum2 = _build_prefix_sums(sorted_array, sorted_weights)
+
+    # cost_matrix[level, i]: optimal cost of clustering prefix [0, i] into
+    # level+1 clusters. boundary[level, i]: left edge of the last cluster.
+    cost_matrix = np.empty((k, n))
+    boundary = np.empty((k, n), np.int64)
+
+    for i in range(n):
+        cost_matrix[0, i] = _cost(cumw, cumsum, cumsum2, 0, i)
+        boundary[0, i] = 0
+
+    argmins = np.empty(n, np.int64)
+    for level in range(1, k):
+        prev_costs = cost_matrix[level - 1]
+        rows = np.arange(n)
+        cols = np.arange(n)
+        _smawk(rows, cols, prev_costs, cumw, cumsum, cumsum2, argmins)
+        for i in range(n):
+            argmin = argmins[i]
+            cost_matrix[level, i] = _matrix_value(i, argmin, prev_costs, cumw, cumsum, cumsum2)
+            boundary[level, i] = argmin
+
+    return _backtrack(boundary, cumw, sorted_array, k)
+
+
+def cluster(
+    array: Sequence[float] | np.ndarray,
+    k: int,
+    *,
+    weights: Sequence[float] | np.ndarray | None = None,
+) -> Clustered:
+    """Cluster 1D data into ``k`` groups minimizing the within-cluster SSE.
+
+    Globally optimal via dynamic programming + SMAWK. Drop-in replacement for
+    ``coremltools._deps._kmeans1d.cluster``.
+
+    Args:
+        array (Sequence[float] | np.ndarray): The 1D values to cluster.
+        k (int): Desired number of clusters; clamped to ``len(array)``.
+        weights (Sequence[float] | np.ndarray | None): Optional per-point weights
+            for weighted (sensitive) k-means. Must match ``len(array)`` if given.
+
+    Returns:
+        Clustered: Namedtuple ``(clusters, centroids)``. ``clusters`` is an int64
+        array of per-point labels in original order, indexing into ``centroids``,
+        an ascending float64 array of length ``min(k, len(array))``.
+
+    Raises:
+        ValueError: If ``k <= 0``; ``array`` is empty or contains non-finite
+            values; or ``weights`` has the wrong length, is non-finite, contains
+            a negative value, or sums to zero. (coremltools silently produces NaN
+            for these; we fail loudly instead.)
+    """
+    values = np.ascontiguousarray(array, dtype=np.float64).ravel()
+    n = values.shape[0]
+    if k <= 0:
+        raise ValueError(f"Invalid k: {k}")
+    if n == 0:
+        raise ValueError("Cannot cluster an empty array.")
+    if not np.isfinite(values).all():
+        raise ValueError("array must contain only finite values.")
+    k = min(k, n)
+
+    if weights is None:
+        point_weights = np.ones(n, dtype=np.float64)
+    else:
+        point_weights = np.ascontiguousarray(weights, dtype=np.float64).ravel()
+        if point_weights.shape[0] != n:
+            raise ValueError(
+                f"weights length ({point_weights.shape[0]}) must match array length ({n})."
+            )
+        if not np.isfinite(point_weights).all():
+            raise ValueError("weights must contain only finite values.")
+        if (point_weights < 0.0).any():
+            raise ValueError("weights must be non-negative.")
+        if point_weights.sum() <= 0.0:
+            raise ValueError("weights must sum to a positive value.")
+
+    order = np.argsort(values)
+    sorted_clusters, centroids = _cluster_sorted(values[order], point_weights[order], k)
+
+    clusters = np.empty(n, dtype=np.int64)
+    clusters[order] = sorted_clusters
+    return Clustered(clusters=clusters, centroids=centroids)

--- a/src/coreai_opt/coreai_utils/_utils/palettize_utils.py
+++ b/src/coreai_opt/coreai_utils/_utils/palettize_utils.py
@@ -18,6 +18,7 @@ from typing import cast
 
 import numpy as np
 
+from coreai_opt._utils import _kmeans1d
 from coreai_opt.coreai_utils._coreai_imports import (
     Operation,
     _get_constant_value_as_np_array,
@@ -28,14 +29,6 @@ from coreai_opt.coreai_utils.common import CompressionGranularity as _Compressio
 logger = logging.getLogger(__name__)
 
 _CONV2D_OP = "coreai.conv2d"
-
-try:
-    import kmeans1d as _kmeans1d
-
-    _HAS_KMEANS1D = True
-except ImportError:
-    _kmeans1d = None  # type: ignore[assignment]
-    _HAS_KMEANS1D = False
 
 LutParams = namedtuple("LutParams", "indices lut vector_axis")
 
@@ -99,8 +92,7 @@ def _get_kmeans_lookup_table_and_weight(
         weight.shape[1] == 1 and num_weights >= 10_000 and weight.dtype == np.float16
     )
 
-    if (is_better_to_use_kmeans1d and _HAS_KMEANS1D) or force_kmeans1d:
-        assert _HAS_KMEANS1D, "Unable to import kmeans1d, please make sure it's installed."
+    if is_better_to_use_kmeans1d or force_kmeans1d:
         values, indices, counts = np.unique(weight, return_inverse=True, return_counts=True)
         indices = indices.flatten()
         n_clusters = min(len(values), lut_len)
@@ -116,11 +108,6 @@ def _get_kmeans_lookup_table_and_weight(
                 "scikit-learn is required for k-means quantization."
                 ' To install, run: "pip install scikit-learn".'
             ) from err
-        if is_better_to_use_kmeans1d:
-            logger.warning(
-                "It would be better to use kmeans1d but that is not available. "
-                "Using scikit-learn for K-means."
-            )
         n_clusters = min(num_weights, lut_len)
         kmeans = KMeans(n_clusters, init="k-means++", tol=1e-2, n_init=1, random_state=0).fit(
             weight

--- a/src/coreai_opt/palettization/kmeans/kmeans_fake_palettize.py
+++ b/src/coreai_opt/palettization/kmeans/kmeans_fake_palettize.py
@@ -8,8 +8,8 @@ from collections.abc import Callable
 
 import numpy as np
 import torch
-from coremltools._deps import _kmeans1d
 
+from coreai_opt._utils import _kmeans1d
 from coreai_opt.config.spec import CompressionTargetTensor
 from coreai_opt.palettization.spec import (
     PalettizationGranularity,
@@ -202,9 +202,7 @@ class _KMeansFakePalettize(_FakePalettizeImplBase):
             # float32, matching the block-weight handling in _cluster_weights_1d.
             if sensitivities.dtype == torch.bfloat16:
                 sensitivities = sensitivities.float()
-            sensitivities = self.reshape_strategy.reshape_for_kmeans(
-                sensitivities, axis
-            )
+            sensitivities = self.reshape_strategy.reshape_for_kmeans(sensitivities, axis)
             block_sensitivities = self.granularity.get_blocks_to_cluster(sensitivities)
         else:
             block_sensitivities = [None] * len(block_weights_to_cluster)
@@ -443,9 +441,7 @@ class _KMeansFakePalettize(_FakePalettizeImplBase):
             and (np.max(block_weight_flatten)) <= np.finfo(np.float16).max
             and np.min(block_weight_flatten) >= np.finfo(np.float16).min
         ):
-            values, indices, counts = self._reduce_weights_to_cluster(
-                block_weight_flatten
-            )
+            values, indices, counts = self._reduce_weights_to_cluster(block_weight_flatten)
             num_clusters = min(len(values), num_clusters)
             if block_sensitivity_flatten is not None:
                 counts = np.bincount(indices, weights=block_sensitivity_flatten)
@@ -570,9 +566,7 @@ class _KMeansFakePalettize(_FakePalettizeImplBase):
 
             # Rounding
             scale = 10**self.rounding_precision
-            block_weight_flatten = (
-                np.round(block_weight_flatten.astype(np.float32) * scale) / scale
-            )
+            block_weight_flatten = np.round(block_weight_flatten.astype(np.float32) * scale) / scale
 
         # To speed up parallel kmeans, use numpy.unique instead of
         # torch.unique in multiprocessing setting.
@@ -610,9 +604,7 @@ class _KMeansFakePalettize(_FakePalettizeImplBase):
         Also scale the parameter using the computed scales.
         """
         flattened_weight = weight.flatten(1)
-        per_channel_scale = torch.max(
-            torch.abs(flattened_weight), dim=1, keepdim=True
-        ).values
+        per_channel_scale = torch.max(torch.abs(flattened_weight), dim=1, keepdim=True).values
         # Handle zero scales
         per_channel_scale[per_channel_scale == 0] = 1
         scaled_weight = flattened_weight / per_channel_scale
@@ -622,9 +614,7 @@ class _KMeansFakePalettize(_FakePalettizeImplBase):
 
         return scaled_weight
 
-    def _unscale_by_per_channel_scale(
-        self, scaled_weight: torch.Tensor
-    ) -> torch.Tensor:
+    def _unscale_by_per_channel_scale(self, scaled_weight: torch.Tensor) -> torch.Tensor:
         """
         Re-scale the parameter back to its original range by multiplying
         per channel scales.

--- a/tests/test_utils/test_kmeans1d.py
+++ b/tests/test_utils/test_kmeans1d.py
@@ -1,0 +1,251 @@
+# Copyright 2026 Apple Inc.
+#
+# Use of this source code is governed by a BSD-3-Clause license that can
+# be found in the LICENSE file or at https://opensource.org/licenses/BSD-3-Clause
+
+"""Equivalence and behavior tests for the Numba 1D k-means.
+
+The equivalence tests use coremltools (a test-only dependency) as the reference
+oracle; it is imported directly, so this module requires coremltools and errors
+if it is not installed. The Numba kernels JIT-compile on first use; with
+cache=True the cost is paid once and reused across the session.
+"""
+
+import numpy as np
+import pytest
+from coremltools._deps import _kmeans1d as ct_kmeans1d
+
+from coreai_opt._utils import _kmeans1d
+
+_RTOL = 1e-9
+_ATOL = 1e-9
+
+# Discrete, strictly-positive weight values (with ties) for the weighted tests.
+_WEIGHT_CHOICES = np.array([1.0, 2.0, 3.0, 4.0])
+
+
+def _assert_equivalent(array, k, weights=None, exact_labels=True):
+    """Assert our cluster() matches coremltools on centroids and reconstruction.
+
+    Labels are compared exactly only when ``exact_labels`` is True (distinct
+    input values); otherwise just the per-point centroid mapping is compared,
+    since the C++ unstable sort makes tie labels non-reproducible while the
+    palettized output stays identical.
+    """
+    reference = ct_kmeans1d.cluster(array, k, weights=weights)
+    ours = _kmeans1d.cluster(array, k, weights=weights)
+
+    ref_centroids = np.asarray(reference.centroids, dtype=np.float64)
+    our_centroids = np.asarray(ours.centroids, dtype=np.float64)
+    ref_clusters = np.asarray(reference.clusters)
+    our_clusters = np.asarray(ours.clusters)
+
+    np.testing.assert_allclose(our_centroids, ref_centroids, rtol=_RTOL, atol=_ATOL)
+
+    # The centroid each point maps to must always match, ties or not.
+    np.testing.assert_allclose(
+        our_centroids[our_clusters], ref_centroids[ref_clusters], rtol=_RTOL, atol=_ATOL
+    )
+
+    if exact_labels:
+        np.testing.assert_array_equal(our_clusters, ref_clusters)
+
+
+def _inertia(points, weights, clusters, centroids):
+    """Weighted within-cluster sum of squared deviations (port of coremltools' helper)."""
+    points = np.asarray(points, dtype=np.float64)
+    weights = np.ones_like(points) if weights is None else np.asarray(weights, dtype=np.float64)
+    centroids = np.asarray(centroids, dtype=np.float64)
+    clusters = np.asarray(clusters)
+    return float(np.sum(weights * (points - centroids[clusters]) ** 2))
+
+
+class TestEquivalence:
+    """Numba clustering must match the coremltools oracle."""
+
+    @pytest.mark.parametrize("n", [2, 5, 50, 2_000])
+    @pytest.mark.parametrize("k", [2, 4, 16, 64, 256])
+    def test_equivalence_unweighted(self, n, k):
+        rng = np.random.default_rng(n * 1000 + k)
+        # Continuous random values are distinct with probability 1, so labels match.
+        array = rng.standard_normal(n)
+        _assert_equivalent(array, k, exact_labels=True)
+
+    @pytest.mark.parametrize("n", [5, 500, 2_000])
+    @pytest.mark.parametrize("k", [2, 4, 16, 64, 256])
+    def test_equivalence_weighted(self, n, k):
+        rng = np.random.default_rng(n + k)
+        array = rng.standard_normal(n)
+        # Discrete, strictly-positive weights (with ties) mirror the count-weighting path.
+        weights = rng.choice(_WEIGHT_CHOICES, size=n)
+        _assert_equivalent(array, k, weights=weights, exact_labels=True)
+
+    @pytest.mark.parametrize("n", [10_000, 20_000, 50_000, 100_000])
+    @pytest.mark.parametrize("k", [4, 64])
+    def test_equivalence_large_n(self, n, k):
+        # O(k*n) time and memory: n=1e5 x k=64 is ~100 MB per DP table. 1e6/1e7 are
+        # infeasible for the exact DP (both numba and coremltools OOM identically).
+        rng = np.random.default_rng(n + k)
+        array = rng.standard_normal(n)
+        _assert_equivalent(array, k, exact_labels=True)
+
+    def test_equivalence_weighted_integer_counts(self):
+        # Mirrors the fast/dedup path: cluster unique values weighted by counts.
+        rng = np.random.default_rng(7)
+        raw = np.round(rng.standard_normal(5000).astype(np.float16).astype(np.float32), 4)
+        values, counts = np.unique(raw, return_counts=True)
+        _assert_equivalent(values, 16, weights=counts.astype(np.float64), exact_labels=True)
+
+    @pytest.mark.parametrize(
+        "array, k",
+        [
+            ([5.0, 5.0, 5.0], 3),
+            ([1.0, 1.0, 9.0], 3),
+            ([-5.0, -5.0, -5.0], 3),
+            ([2.0, 2.0, 2.0, 2.0], 4),
+        ],
+        ids=["all-equal", "two-distinct", "all-negative-equal", "four-equal"],
+    )
+    def test_collapse_fewer_than_k_clusters_matches_coremltools(self, array, k):
+        # When k exceeds the number of distinct values, the optimum uses fewer than
+        # k clusters and coremltools zero-fills the unused leading centroids. We must
+        # match, including the non-ascending [0.0, 0.0, -5.0] padding for negatives.
+        _assert_equivalent(np.array(array), k, exact_labels=False)
+
+    def test_k_greater_than_n_is_clamped(self):
+        array = np.array([1.0, 5.0, 9.0, 13.0, 17.0])
+        result = _kmeans1d.cluster(array, 16)
+        assert len(result.centroids) == len(array)
+        _assert_equivalent(array, 16, exact_labels=True)
+
+    def test_fp16_input_with_duplicates(self):
+        # fp16 has few representable values, so duplicates (ties) are expected.
+        rng = np.random.default_rng(3)
+        array = rng.standard_normal(4000).astype(np.float16)
+        _assert_equivalent(array, 16, exact_labels=False)
+
+    def test_explicit_duplicates_reconstruction_matches(self):
+        array = np.array([1.0, 1.0, 1.0, 5.0, 5.0, 9.0, 9.0, 9.0, 9.0])
+        _assert_equivalent(array, 3, exact_labels=False)
+
+
+class TestKmeans1DBehavior:
+    """Properties and input validation of the numba cluster() surface (no oracle)."""
+
+    def test_weights_equal_repetition(self):
+        # Weighting a value by w is equivalent to repeating it w times.
+        repeated = np.array([1.0, 1.0, 5.0, 5.0, 5.0, 9.0])
+        unique_values = np.array([1.0, 5.0, 9.0])
+        counts = np.array([2.0, 3.0, 1.0])
+
+        repeated_result = _kmeans1d.cluster(repeated, 2)
+        weighted_result = _kmeans1d.cluster(unique_values, 2, weights=counts)
+
+        np.testing.assert_allclose(
+            np.sort(np.unique(repeated_result.centroids)),
+            np.sort(weighted_result.centroids),
+            rtol=_RTOL,
+            atol=_ATOL,
+        )
+
+    def test_centroids_are_ascending_and_labels_in_range(self):
+        rng = np.random.default_rng(11)
+        array = rng.standard_normal(1000)
+        result = _kmeans1d.cluster(array, 16)
+
+        centroids = np.asarray(result.centroids)
+        clusters = np.asarray(result.clusters)
+        assert np.all(np.diff(centroids) >= 0), "centroids must be ascending"
+        assert clusters.min() >= 0 and clusters.max() < len(centroids)
+        assert clusters.shape == array.shape
+        assert centroids.dtype == np.float64
+
+    def test_accepts_list_and_preserves_original_order(self):
+        # A plain Python list (the doc-script call style) must work, and labels are
+        # returned in the original (unsorted) order.
+        result = _kmeans1d.cluster([9.0, 0.1, 9.1, 0.0], 2)
+        clusters = np.asarray(result.clusters)
+        centroids = np.asarray(result.centroids)
+        # Points 0,2 are the large cluster; 1,3 the small one.
+        assert clusters[0] == clusters[2]
+        assert clusters[1] == clusters[3]
+        assert clusters[0] != clusters[1]
+        np.testing.assert_allclose(centroids, [0.05, 9.05], rtol=_RTOL, atol=_ATOL)
+
+    def test_invalid_arguments_raise(self):
+        with pytest.raises(ValueError):
+            _kmeans1d.cluster([1.0, 2.0], 0)
+        with pytest.raises(ValueError):
+            _kmeans1d.cluster([], 2)
+        with pytest.raises(ValueError):
+            _kmeans1d.cluster([1.0, 2.0, 3.0], 2, weights=[1.0, 1.0])
+
+    def test_non_finite_inputs_raise(self):
+        # Fail loud rather than propagating silent NaN centroids into the LUT.
+        with pytest.raises(ValueError):
+            _kmeans1d.cluster([1.0, np.nan, 3.0], 2)
+        with pytest.raises(ValueError):
+            _kmeans1d.cluster([1.0, np.inf, 3.0], 2)
+
+    def test_invalid_weights_raise(self):
+        with pytest.raises(ValueError):  # negative weight
+            _kmeans1d.cluster([1.0, 2.0, 3.0], 2, weights=[1.0, -1.0, 1.0])
+        with pytest.raises(ValueError):  # weights sum to zero
+            _kmeans1d.cluster([1.0, 2.0, 3.0], 2, weights=[0.0, 0.0, 0.0])
+        with pytest.raises(ValueError):  # non-finite weight
+            _kmeans1d.cluster([1.0, 2.0, 3.0], 2, weights=[1.0, np.nan, 1.0])
+
+
+class TestsKmeans1dFromCoremltools:
+    """Fixed-value oracle cases ported from coremltools' own kmeans1d test suite
+    (``coremltools/deps/kmeans1d/tests/test_kmeans1d.py``).
+
+    These assert the numba output against hardcoded known-good values; all inputs
+    are distinct-valued, so labels are unambiguous.
+    """
+
+    def test_cluster(self):
+        array = [4.0, 4.1, 4.2, -50, 200.2, 200.4, 200.9, 80, 100, 102]
+        result = _kmeans1d.cluster(array, 4)
+        np.testing.assert_array_equal(result.clusters, [1, 1, 1, 0, 3, 3, 3, 2, 2, 2])
+        np.testing.assert_allclose(
+            result.centroids, [-50.0, 4.1, 94.0, 200.5], rtol=_RTOL, atol=_ATOL
+        )
+
+    def test_cluster_with_weights(self):
+        array = [4.0, 4.1, 4.2, -50, 200.2, 200.4, 200.9, 80, 100, 102]
+        weights = [1, 1, 1, 0.125, 4, 1, 1, 3, 2, 2]
+        result = _kmeans1d.cluster(array, 4, weights=weights)
+        np.testing.assert_array_equal(result.clusters, [0, 0, 0, 0, 3, 3, 3, 1, 2, 2])
+        np.testing.assert_allclose(
+            result.centroids, [1.936, 80.0, 101.0, 200.35], rtol=_RTOL, atol=_ATOL
+        )
+
+    def test_weights_vs_repetition(self):
+        values = [10, 24, 16, 12, 20]
+        weights = [3, 1, 4, 2, 3]
+        weighted = _kmeans1d.cluster(values, 2, weights=weights)
+        np.testing.assert_array_equal(weighted.clusters, [0, 1, 1, 0, 1])
+        np.testing.assert_allclose(weighted.centroids, [10.8, 18.5], rtol=_RTOL, atol=_ATOL)
+        np.testing.assert_allclose(
+            _inertia(values, weights, weighted.clusters, weighted.centroids),
+            66.8,
+            rtol=_RTOL,
+            atol=_ATOL,
+        )
+
+        # Weighting by integer counts equals repeating each value that many times.
+        repeated = np.repeat(values, weights)
+        repeated_result = _kmeans1d.cluster(repeated, 2)
+        np.testing.assert_allclose(
+            np.sort(repeated_result.centroids),
+            np.sort(weighted.centroids),
+            rtol=_RTOL,
+            atol=_ATOL,
+        )
+        np.testing.assert_allclose(
+            _inertia(repeated, None, repeated_result.clusters, repeated_result.centroids),
+            66.8,
+            rtol=_RTOL,
+            atol=_ATOL,
+        )


### PR DESCRIPTION
## Description

This PR removes `coremltools` as a required dependency for `coreai-opt`.

The only part of `coremltools` that was being used was `kmeans1d`. We have re-implemented `kmeans1d` in `coreai-opt` using `numba` to keep `coreai-opt` platform-agnostic.

[`numba`](https://numba.readthedocs.io/en/stable/user/5minguide.html) is a JIT compiler for Python that works by adding decorators to Python functions. This is different compared to `coremltools` kmeans1d that relied on AOT compilation of CPP code.

The alternative of using `numba` would be to lazily do AOT compilation in `torch` using `torch.utils.cpp_extension`. This hasn't been tested.

## Performance Benchmarking

`numba` `kmeans1d` is around 1-3x faster than `coremltools` kmeans1d. This is mainly because coremltools `kmeans1d` doesn't compile with `-O3`. Once `-O3` is used, we should see the performance be the same according to [this `numba` forum post](https://numba.discourse.group/t/try-to-understand-why-numba-is-4x-faster-than-c-code-in-the-same-task/1634). AOT C++ is faster at small tensor sizes (10-20 elements) with low `k` as `numba` JIT compilation time is much higher than `kmeans1d` execution time.

I have attached a markdown file where I ran performance comparisons of `numba` and `kmeans1d`:
[benchmark_results.md](https://github.com/user-attachments/files/29614462/benchmark_results.md)

## Testing

1. We have equivalence tests to ensure that numba `kmeans1d` is equivalent to coremltools `kmeans1d` (tolerance is 1e-9)
2. kmeans1d tests are copied over from `coremltools`
3. These tests pass in CI