### PR TITLE
fix(test): change AIModel asset saving to give temp path to AIModel instead of directory

### DIFF
--- a/tests/export/export_utils.py
+++ b/tests/export/export_utils.py
@@ -459,7 +459,8 @@ class MLIRConverter(ModelConverter):
             prefix="mlir_converter_inference",
             suffix=".aimodel",
         ) as tmpdir:
-            asset = converted_model.save_asset(Path(tmpdir))
+            asset_path = Path(tmpdir) / "asset.aimodel"
+            asset = converted_model.save_asset(asset_path)
             async with asset.executable(
                 specialization_options=_get_test_specialization_options(),
             ) as ai_model:

--- a/tests/export/export_utils.py
+++ b/tests/export/export_utils.py
@@ -457,7 +457,6 @@ class MLIRConverter(ModelConverter):
         """Async implementation of MLIR inference."""
         with tempfile.TemporaryDirectory(
             prefix="mlir_converter_inference",
-            suffix=".aimodel",
         ) as tmpdir:
             asset_path = Path(tmpdir) / "asset.aimodel"
             asset = converted_model.save_asset(asset_path)


### PR DESCRIPTION
Verified by running the following commands:
1.`make test PYTEST_ARGS="tests/export --workers 8 --compute-unit-kind=neural_engine --runxfail --max-worker-restart=500"`
2. `make test PYTEST_ARGS="tests/export --workers 1 --compute-unit-kind=neural_engine --runxfail --max-worker-restart=500"`

Neither of these gave the `OSError: [Errno 9] Bad file descriptor` issue

This matches up with `coreai-torch` [documentation](https://apple.github.io/coreai-torch/main/getting-started/quickstart.html#compile-and-run) where they save to `.aimodel` directly