### PR TITLE
build: add render-api-index make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # Use of this source code is governed by a BSD-3-Clause license that can
 # be found in the LICENSE file or at https://opensource.org/licenses/BSD-3-Clause
 
-.PHONY: _maybe_patch_pyproject all api-list build check clean distclean distclean-all docs docs-clean docs-open env env-all env-docs env-highest-torch env-tutorial set-auto-venv test test-cov test-fast test-highest-pytorch test-lowest-pytorch test-slow test-smoke test-tutorials version
+.PHONY: _maybe_patch_pyproject all api-list build check clean distclean distclean-all docs docs-clean docs-open env env-all env-docs env-highest-torch env-tutorial render-api-index set-auto-venv test test-cov test-fast test-highest-pytorch test-lowest-pytorch test-slow test-smoke test-tutorials version
 
 SHELL := /bin/bash
 
@@ -330,6 +330,13 @@ endif
 # Remove documentation build artifacts and autosummary-generated stubs
 docs-clean:
 	@rm -rf $(DOCS_DIR)/build $(DOCS_DIR)/src/api/generated
+
+# Regenerate docs/src/api/index.md from the package tree.
+#
+# Runs the same generator `make docs` invokes during the Sphinx build, so the
+# API index can be refreshed on its own using the base dev env.
+render-api-index:
+	@$(call use_env,VENV) && uv run --no-sync --active python $(MAKEFILE_DIR)docs/scripts/generate_api_index.py
 
 # Build and open documentation in browser
 # Uses --serve so the docs are loaded over HTTP, not file:// — required for

--- a/docs/scripts/generate_api_index.py
+++ b/docs/scripts/generate_api_index.py
@@ -162,7 +162,8 @@ def generate_api_index() -> str:
 
 
 if __name__ == "__main__":
-    repo_root = find_repo_root(__file__)
+    # Anchor on the cwd so `make` writes the invoking repo's index.
+    repo_root = find_repo_root()
     output = repo_root / _OUTPUT_PATH
 
     content = generate_api_index()


### PR DESCRIPTION
- Regenerates docs/src/api/index.md via the standalone generator without the full `make docs` Sphinx build
- Runs under the base dev env, so refreshing the API index no longer requires the docs environment or its toolchain