### PR TITLE
build: add env-lowest-torch make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -259,18 +259,18 @@ test-smoke:
 	echo "All smoke tests passed!"
 
 # Run tests on lowest supported PyTorch version (pass PYTEST_ARGS for custom flags)
-test-lowest-pytorch:
+test-lowest-pytorch: env-lowest-torch
 	@echo "Running tests on lowest PyTorch version supported..."
-	@TORCH_GROUP=$(LOWEST_TORCH_GROUP) $(call use_env,VENV_LOWEST_TORCH) && \
+	@source $(VENV_LOWEST_TORCH)/bin/activate && \
 	echo "Testing with lowest supported PyTorch versions" && \
 	uv run --no-sync --active python $(SCRIPTS)/make/log_versions.py && \
 	$(RUN_TESTS) $(PYTEST_ARGS) && \
 	echo "All tests passed!"
 
 # Run tests on highest supported PyTorch version (pass PYTEST_ARGS for custom flags)
-test-highest-pytorch:
+test-highest-pytorch: env-highest-torch
 	@echo "Running tests on highest PyTorch version supported..."
-	@TORCH_GROUP=$(HIGHEST_TORCH_GROUP) $(call use_env,VENV_HIGHEST_TORCH) && \
+	@source $(VENV_HIGHEST_TORCH)/bin/activate && \
 	echo "Testing with latest supported PyTorch versions" && \
 	uv run --no-sync --active python $(SCRIPTS)/make/log_versions.py && \
 	$(RUN_TESTS) $(PYTEST_ARGS) && \

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # Use of this source code is governed by a BSD-3-Clause license that can
 # be found in the LICENSE file or at https://opensource.org/licenses/BSD-3-Clause
 
-.PHONY: _maybe_patch_pyproject all api-list build check clean distclean distclean-all docs docs-clean docs-open env env-all env-docs env-highest-torch env-tutorial render-api-index set-auto-venv test test-cov test-fast test-highest-pytorch test-lowest-pytorch test-slow test-smoke test-tutorials version
+.PHONY: _maybe_patch_pyproject all api-list build check clean distclean distclean-all docs docs-clean docs-open env env-all env-docs env-highest-torch env-lowest-torch env-tutorial render-api-index set-auto-venv test test-cov test-fast test-highest-pytorch test-lowest-pytorch test-slow test-smoke test-tutorials version
 
 SHELL := /bin/bash
 
@@ -189,6 +189,11 @@ env: _maybe_patch_pyproject
 env-highest-torch: _maybe_patch_pyproject
 	@TORCH_GROUP=$(HIGHEST_TORCH_GROUP) $(SETUP_ENV) --venv $(VENV_HIGHEST_TORCH) --python-version $(PYTHON_VERSION)
 	@$(call write_active_venv,$(VENV_HIGHEST_TORCH))
+
+# Set up development environment with lowest supported PyTorch version
+env-lowest-torch: _maybe_patch_pyproject
+	@TORCH_GROUP=$(LOWEST_TORCH_GROUP) $(SETUP_ENV) --venv $(VENV_LOWEST_TORCH) --python-version $(PYTHON_VERSION)
+	@$(call write_active_venv,$(VENV_LOWEST_TORCH))
 
 # Set up environment for running tutorials (quantization notebook)
 env-tutorial: _maybe_patch_pyproject


### PR DESCRIPTION
Mirrors env-highest-torch to give local dev a way to create a venv pinned to the lowest supported PyTorch version, matching what test-lowest-pytorch already builds on demand.