### PR TITLE
ci: add PyPI trusted-publishing release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,148 @@
+name: Release
+
+run-name: 'Release ${{ github.ref_name }} · @${{ github.actor }}'
+
+# Publishing to PyPI uses Trusted Publishing (OIDC) — no API token is stored.
+# A release manager pushes a `vMAJOR.MINOR.PATCH` tag; the `build` and
+# `smoke-test` jobs run automatically, then the `publish` job pauses on the
+# `pypi` GitHub environment until a reviewer approves it. That environment's
+# protection rules (required reviewers, prevent-self-review so the tag pusher
+# can't approve their own release, and a wait timer) live in the repo's
+# Environment settings, not in this file.
+on:
+  push:
+    tags:
+      # Strictly vMAJOR.MINOR.PATCH with numeric parts (e.g. v0.2.2). This is a
+      # glob, not a regex: `.` is a literal dot and `[0-9]` a digit range. The
+      # filter must match the entire tag, so pre-releases (v1.2.3rc1 — the
+      # trailing `rc1` is left unmatched) and other non-release tags never start
+      # the release run. The `pypi` environment tag rule and approval gate are
+      # secondary controls; the version guard below is the final backstop.
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+  # Manual dry run: builds and smoke-tests the current ref but never publishes
+  # (the publish job is gated to tag pushes). Trigger from the Actions tab
+  # ("Release" -> "Run workflow") or `gh workflow run release.yml --ref <branch>`.
+  workflow_dispatch:
+
+# Least privilege by default; the publish job opts into `id-token: write`.
+permissions:
+  contents: read
+
+concurrency:
+  # Serialize releases per tag and never cancel an in-flight publish.
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  # ── Build the exact wheel + sdist that will be smoke-tested and published. ──
+  build:
+    name: Build distributions
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      - name: Install uv
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        with:
+          enable-cache: false
+      - name: Verify the tag matches the package version
+        # The published version comes from src/coreai_opt/_about.py, not the tag.
+        # Fail early if they disagree so we never publish a mismatched/duplicate
+        # version (PyPI uploads are immutable and cannot be overwritten).
+        # Skipped on manual dry runs, where the ref is a branch, not a vX.Y.Z tag.
+        if: github.event_name == 'push'
+        run: |
+          tag="${GITHUB_REF_NAME}"
+          version="$(python3 -c "import runpy; print(runpy.run_path('src/coreai_opt/_about.py')['__version__'])")"
+          echo "tag=${tag}  package version=${version}"
+          if [ "${tag}" != "v${version}" ]; then
+            echo "::error::Tag ${tag} does not match package version v${version} (src/coreai_opt/_about.py). Bump __version__ to match the release tag."
+            exit 1
+          fi
+      - name: Build wheel and sdist
+        run: make build
+      - name: Upload distributions
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: dist
+          path: dist/
+          if-no-files-found: error
+
+  # ── Smoke test the exact built wheel and sdist via `make test-smoke`. ──
+  # Reuses the repo's smoke suite (ci/nox/noxfile.py → tests/test_smoke.py) but
+  # points it at the pre-built artifact instead of rebuilding, so we test the
+  # bytes we are about to publish. `make test-smoke` runs across every supported
+  # Python version internally.
+  smoke-test:
+    name: Smoke test (${{ matrix.format }}, ${{ matrix.torch_group }})
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    env:
+      INSTALL_PRECOMMIT: 'false'
+    strategy:
+      fail-fast: false
+      matrix:
+        # Test both distribution formats against every supported torch version,
+        # mirroring the PR CI smoke matrix (ci.yaml).
+        format: [wheel, sdist]
+        torch_group: [torch_2_8, torch_2_9, torch_2_10, torch_2_11]
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      - name: Install uv
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        with:
+          enable-cache: false
+      - name: Download distributions
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: dist
+          path: dist/
+      - name: Smoke test the built ${{ matrix.format }} against ${{ matrix.torch_group }}
+        run: |
+          # Expand the glob to the single built artifact; the `test -f` below
+          # fails the job if it's missing or if more than one matched.
+          case "${{ matrix.format }}" in
+            wheel) dist="$(echo dist/*.whl)" ;;
+            sdist) dist="$(echo dist/*.tar.gz)" ;;
+          esac
+          test -f "${dist}" || { echo "::error::Expected exactly one ${{ matrix.format }} in dist/"; exit 1; }
+          echo "Smoke testing ${dist} against ${{ matrix.torch_group }}"
+          make test-smoke SMOKE_TEST_DIST="${dist}" TORCH_GROUP="${{ matrix.torch_group }}"
+
+  # ── Publish to PyPI via Trusted Publishing. Only this job holds `id-token`. ──
+  # It builds nothing and runs no project code: it just downloads the vetted
+  # artifact and uploads it, keeping build/test dependencies out of the
+  # OIDC-privileged job.
+  publish:
+    name: Publish to PyPI
+    needs: [build, smoke-test]
+    # Publish only on a tag push (never on a manual dry run) and never from forks.
+    if: github.event_name == 'push' && github.repository == 'apple/coreai-optimization'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    environment:
+      name: pypi
+      url: https://pypi.org/p/coreai-opt
+    permissions:
+      id-token: write # mint the OIDC token PyPI validates for Trusted Publishing
+      contents: read
+    steps:
+      - name: Install uv
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        with:
+          enable-cache: false
+      - name: Download distributions
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: dist
+          path: dist/
+      - name: Publish to PyPI
+        # `always` requires Trusted Publishing (OIDC) — no fallback to tokens.
+        run: uv publish --trusted-publishing always

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,8 +22,8 @@ The API surface is intentionally limited. This keeps the library reliable, well-
 Set up the environment as described in [README.md](README.md#getting-started). Then, from the activated venv:
 
 ```shell
-# Build the package.
-make build
+# Build the package (development build).
+make build-dev
 
 # Build the documentation.
 make docs

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # Use of this source code is governed by a BSD-3-Clause license that can
 # be found in the LICENSE file or at https://opensource.org/licenses/BSD-3-Clause
 
-.PHONY: _maybe_patch_pyproject all api-list build check clean distclean distclean-all docs docs-clean docs-open env env-all env-docs env-highest-torch env-lowest-torch env-tutorial render-api-index set-auto-venv test test-cov test-fast test-highest-pytorch test-lowest-pytorch test-slow test-smoke test-tutorials version
+.PHONY: _maybe_patch_pyproject all api-list build build-dev check clean distclean distclean-all docs docs-clean docs-open env env-all env-docs env-highest-torch env-lowest-torch env-tutorial render-api-index set-auto-venv test test-cov test-fast test-highest-pytorch test-lowest-pytorch test-slow test-smoke test-tutorials version
 
 SHELL := /bin/bash
 
@@ -63,6 +63,13 @@ LOWEST_TORCH_GROUP := torch_2_8
 # environment-building target (env, test, test-smoke, docs, ...) pins to.
 TORCH_GROUP ?= $(HIGHEST_TORCH_GROUP)
 export TORCH_GROUP
+
+# Optional path to a pre-built distribution (wheel or sdist) for `test-smoke` to
+# install instead of building from source; consumed by the nox smoke session via
+# $SMOKE_TEST_DIST (empty = build from source). Exported like TORCH_GROUP so it
+# reaches the nox subprocess.
+SMOKE_TEST_DIST ?=
+export SMOKE_TEST_DIST
 
 # Documentation directory. Defaults to $(MAKEFILE_DIR)docs so the same recipe
 # works in both contexts:
@@ -174,7 +181,7 @@ endif
 # =============================================================================
 
 # Default target - run full workflow
-all: clean distclean-all env-all check test-lowest-pytorch test-highest-pytorch build
+all: clean distclean-all env-all check test-lowest-pytorch test-highest-pytorch build-dev
 
 # =============================================================================
 # Environment Setup
@@ -210,8 +217,17 @@ env-all: _maybe_patch_pyproject
 # Build
 # =============================================================================
 
-# Build package
+# Build the canonical, publishable distribution (wheel + sdist) via the uv build
+# frontend. `--no-sources` ignores [tool.uv.sources], so the artifact doesn't
+# depend on uv-specific index overrides — the recommended way to build for
+# publication. This is what the release workflow runs.
 build:
+	@uv build --no-sources
+
+# Build the development distribution with build.py (standard version; build.py
+# also supports a PEP 440 .dev version via --dev). Used by contributors and the
+# smoke tests.
+build-dev:
 	@$(call use_env,VENV) && uv run --no-sync --active python $(SCRIPTS)/make/build.py
 
 # =============================================================================
@@ -252,6 +268,9 @@ test-slow:
 
 # Run smoke tests only (pass PYTEST_ARGS for custom flags, e.g., make test-smoke PYTEST_ARGS="--junitxml=results.xml").
 # Pass TORCH_GROUP to smoke test against a specific torch version (default: HIGHEST_TORCH_GROUP).
+# Pass SMOKE_TEST_DIST=<path to a .whl or .tar.gz> to smoke test a pre-built
+# distribution instead of building one from source (used by the release
+# workflow to test the exact artifact being published).
 test-smoke:
 	@$(call use_env,VENV) && \
 	echo "Running smoke tests..." && \

--- a/ci/nox/noxfile.py
+++ b/ci/nox/noxfile.py
@@ -36,32 +36,54 @@ options.error_on_missing_interpreters = True
 
 TORCH_GROUP = os.environ.get("TORCH_GROUP")
 
+# Optional path to a pre-built distribution (wheel or sdist) to smoke test
+# instead of building one from source. Set by the release workflow so the exact
+# artifact that will be uploaded to PyPI is what gets tested. Relative paths are
+# resolved against the working directory (the project root, set just below).
+SMOKE_TEST_DIST = os.environ.get("SMOKE_TEST_DIST")
+
 
 @session(
     python=get_supported_python_versions(),
     uv_extras=["coreai"],
     uv_groups=["test", TORCH_GROUP],
+    # When testing a pre-built distribution, install only the project's
+    # dependencies (not the project from source) so the distribution under test
+    # is the sole coreai_opt on the path.
+    uv_no_install_project=bool(SMOKE_TEST_DIST),
 )
 def smoke_tests(session: Session) -> None:
-    """Smoke test the package build and coreai_opt imports and basic functionality.
+    """Smoke test the package and coreai_opt imports and basic functionality.
 
-    Builds the package using the nox session's Python version, installs it
-    in a clean environment, and runs smoke tests to verify functionality.
+    By default, builds the package using the nox session's Python version,
+    installs it in a clean environment, and runs smoke tests to verify
+    functionality. When the ``SMOKE_TEST_DIST`` environment variable points to a
+    pre-built wheel or sdist, that distribution is installed and tested instead
+    of building one — used by the release workflow to smoke test the exact
+    artifact that will be published to PyPI.
     """
     change_dir_to_project_root(session)
-    session.log(f"Building package with Python {session.python}")
-    session.install("build")
-    session.run("make", "build", external=True)
-    session.log("Installing built package")
 
-    # Find the built wheel
-    wheels = list(Path("dist").glob("*.whl"))
-    if not wheels:
-        session.error(f"Build unsuccessful for Python {session.python}")
-        session.error("No wheel found in dist/")
-    latest_wheel = max(wheels, key=lambda p: p.stat().st_mtime)
-    session.install(str(latest_wheel))
-    session.log("Build Succeeded!")
+    if SMOKE_TEST_DIST:
+        dist_path = Path(SMOKE_TEST_DIST).absolute()
+        if not dist_path.is_file():
+            session.error(f"SMOKE_TEST_DIST does not point to a file: {dist_path}")
+        session.log(f"Installing pre-built distribution: {dist_path}")
+        session.install(str(dist_path))
+    else:
+        session.log(f"Building package with Python {session.python}")
+        session.install("build")
+        session.run("make", "build-dev", external=True)
+        session.log("Installing built package")
+
+        # Find the built wheel
+        wheels = list(Path("dist").glob("*.whl"))
+        if not wheels:
+            session.error(f"Build unsuccessful for Python {session.python}")
+            session.error("No wheel found in dist/")
+        latest_wheel = max(wheels, key=lambda p: p.stat().st_mtime)
+        session.install(str(latest_wheel))
+        session.log("Build Succeeded!")
 
     # setuptools is needed by torch.utils.cpp_extension (used by PT2E quantization);
     # required on Python 3.12+ where distutils was removed from stdlib.


### PR DESCRIPTION
- `release.yml`: on a `vX.Y.Z` tag, build the wheel + sdist, smoke-test them across the torch 2.8-2.11 matrix, then publish to PyPI via `uv` + OIDC Trusted Publishing, gated on the approval-protected `pypi` environment; `workflow_dispatch` runs build + smoke as a no-publish dry run
- `noxfile.py`: add `SMOKE_TEST_DIST` to the smoke session to install a pre-built wheel/sdist (with `uv_no_install_project`) instead of rebuilding, so the published bytes are what get tested
- `Makefile`: export `SMOKE_TEST_DIST` so `make test-smoke` passes it through to nox