### PR TITLE
build: add POST_INSTALL_PIP_ARGS to override venv deps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,6 +95,25 @@ SHELL_RC ?=
 # internal-only venv defaults.
 ENV_ALL_EXTRAS ?= true
 
+# Extra `uv pip install` arguments, applied to a venv after it is synced and to
+# each nox session venv (see ci/nox/noxfile.py). Use it to swap a dependency
+# version for one run without editing pyproject.toml or the lockfile — for
+# example a scheduled job testing against newer upstream builds. Empty (the
+# default) changes nothing.
+POST_INSTALL_PIP_ARGS ?=
+export POST_INSTALL_PIP_ARGS
+
+# Re-apply POST_INSTALL_PIP_ARGS to the venv at $(1).
+#
+# setup_env.sh already does this, so only use it when a recipe installs more
+# packages afterwards that could pull the old version back in (see env-all).
+# Expands to `true` when unset. The empty check uses `$(if ...)` instead of a
+# shell `[ -n "..." ]` test because the args contain their own quotes.
+# Usage: $(call post_install_pip,VENV_PATH)
+define post_install_pip
+$(if $(POST_INSTALL_PIP_ARGS),echo "Applying POST_INSTALL_PIP_ARGS to $(1)" && source $(1)/bin/activate && uv pip install $(POST_INSTALL_PIP_ARGS),true)
+endef
+
 # Local wheelhouse for pre-release wheels not yet on an index.
 # Exported so every recipe-level uv invocation (uv lock, uv sync, uv venv)
 # resolves matching packages from disk without an index lookup. The wildcard
@@ -212,6 +231,7 @@ env-all: _maybe_patch_pyproject
 	@$(SETUP_ENV) --venv $(VENV) --python-version $(PYTHON_VERSION) --all-groups
 	@$(call write_active_venv,$(VENV))
 	@$(ENV_ALL_EXTRAS)
+	@$(call post_install_pip,$(VENV))
 
 # =============================================================================
 # Build
@@ -277,19 +297,24 @@ test-smoke:
 	uv run --no-sync --active nox -f $(MAKEFILE_DIR)ci/nox/noxfile.py -s smoke_tests -- $(PYTEST_ARGS) && \
 	echo "All smoke tests passed!"
 
-# Run tests on lowest supported PyTorch version (pass PYTEST_ARGS for custom flags)
-test-lowest-pytorch: env-lowest-torch
+# Run tests on lowest supported PyTorch version (pass PYTEST_ARGS for custom flags).
+# TORCH_GROUP is already exported, so setting it per target is enough for
+# use_env to pick the right torch build. Use `=`, not `:=`: an including
+# Makefile may change HIGHEST_TORCH_GROUP after this file is read.
+test-lowest-pytorch: TORCH_GROUP = $(LOWEST_TORCH_GROUP)
+test-lowest-pytorch:
 	@echo "Running tests on lowest PyTorch version supported..."
-	@source $(VENV_LOWEST_TORCH)/bin/activate && \
+	@$(call use_env,VENV_LOWEST_TORCH) && \
 	echo "Testing with lowest supported PyTorch versions" && \
 	uv run --no-sync --active python $(SCRIPTS)/make/log_versions.py && \
 	$(RUN_TESTS) $(PYTEST_ARGS) && \
 	echo "All tests passed!"
 
 # Run tests on highest supported PyTorch version (pass PYTEST_ARGS for custom flags)
-test-highest-pytorch: env-highest-torch
+test-highest-pytorch: TORCH_GROUP = $(HIGHEST_TORCH_GROUP)
+test-highest-pytorch:
 	@echo "Running tests on highest PyTorch version supported..."
-	@source $(VENV_HIGHEST_TORCH)/bin/activate && \
+	@$(call use_env,VENV_HIGHEST_TORCH) && \
 	echo "Testing with latest supported PyTorch versions" && \
 	uv run --no-sync --active python $(SCRIPTS)/make/log_versions.py && \
 	$(RUN_TESTS) $(PYTEST_ARGS) && \

--- a/ci/nox/noxfile.py
+++ b/ci/nox/noxfile.py
@@ -10,6 +10,7 @@ This module defines nox sessions to test the coreai-opt package against:
 """
 
 import os
+import shlex
 import sys
 from pathlib import Path
 
@@ -41,6 +42,12 @@ TORCH_GROUP = os.environ.get("TORCH_GROUP")
 # artifact that will be uploaded to PyPI is what gets tested. Relative paths are
 # resolved against the working directory (the project root, set just below).
 SMOKE_TEST_DIST = os.environ.get("SMOKE_TEST_DIST")
+
+# Extra `uv pip install` arguments, applied to the session venv after the
+# package under test is installed. Use it to swap a dependency version for one
+# run without editing pyproject.toml or the lockfile. Split with shlex so
+# quoted version specifiers stay in one piece. Unset means do nothing.
+POST_INSTALL_PIP_ARGS = os.environ.get("POST_INSTALL_PIP_ARGS")
 
 
 @session(
@@ -88,6 +95,11 @@ def smoke_tests(session: Session) -> None:
     # setuptools is needed by torch.utils.cpp_extension (used by PT2E quantization);
     # required on Python 3.12+ where distutils was removed from stdlib.
     session.install("setuptools")
+
+    # Last, so it replaces any version the installed package pinned.
+    if POST_INSTALL_PIP_ARGS:
+        session.log(f"Applying POST_INSTALL_PIP_ARGS: {POST_INSTALL_PIP_ARGS}")
+        session.install(*shlex.split(POST_INSTALL_PIP_ARGS))
 
     session.log("Running smoke tests")
 

--- a/scripts/make/setup_env.sh
+++ b/scripts/make/setup_env.sh
@@ -261,6 +261,26 @@ if ! command -v uv &>/dev/null; then
     exit 1
 fi
 
+# Install POST_INSTALL_PIP_ARGS into the venv, if it is set.
+#
+# Use it to swap a dependency version for one run without editing
+# pyproject.toml or the lockfile; only the venv changes. Called from both exits
+# below, so it runs whether or not a sync was needed. Unset means do nothing.
+#
+# `eval` is needed because the arguments contain their own quotes.
+apply_post_install_pip_args() {
+    [[ -n "${POST_INSTALL_PIP_ARGS:-}" ]] || return 0
+    echo ""
+    echo "=========================================="
+    echo "Applying POST_INSTALL_PIP_ARGS"
+    echo "=========================================="
+    echo "Venv: $VENV"
+    echo "Args: $POST_INSTALL_PIP_ARGS"
+    echo ""
+    source "$VENV/bin/activate"
+    eval "uv pip install $POST_INSTALL_PIP_ARGS"
+}
+
 # --ensure mode: skip setup if venv exists and required deps are already installed.
 # This is the fast path called by Make targets to avoid re-running full setup.
 if [[ "$ENSURE_MODE" == "true" ]] && [ -f "$VENV/bin/python" ]; then
@@ -299,6 +319,7 @@ if [[ "$ENSURE_MODE" == "true" ]] && [ -f "$VENV/bin/python" ]; then
     fi
 
     if "$VENV/bin/python" -c "$IMPORT_STMTS" 2>/dev/null; then
+        apply_post_install_pip_args
         exit 0
     fi
 
@@ -368,6 +389,8 @@ if [[ ${#EXCLUDE_GROUPS[@]} -gt 0 ]]; then
 fi
 echo "Running: ${SYNC_CMD[*]}"
 "${SYNC_CMD[@]}"
+
+apply_post_install_pip_args
 
 echo ""
 echo "[3/3] Installing hook dependencies and configuring pre-commit hooks..."


### PR DESCRIPTION
- Lets a single run swap a dependency version without editing `pyproject.toml` or the lockfile — only the venv changes, so nothing is left behind for the next run.
- Applied in three places so every entrypoint honors it: `setup_env.sh` (after sync and on the `--ensure` fast path), the `post_install_pip` macro in `env-all` (which installs extras that could pull the old version back in), and nox session venvs in `ci/nox/noxfile.py`.
- Always installed *last* so it wins over versions pinned by the package under test.
- `test-lowest-pytorch` / `test-highest-pytorch` now select their torch build via a target-specific `TORCH_GROUP` and `use_env`, instead of depending on `env-*-torch`. The env is provisioned through the same fast path as the other test targets, so the override applies there too.