### PR TITLE
feat(quantization): add constraint-queue qspec reconciler for graph mode

### DIFF
--- a/docs/architecture_notes/README.md
+++ b/docs/architecture_notes/README.md
@@ -1,0 +1,28 @@
+# Architecture Notes
+
+Explanations of how large components of coreai-opt work, and why they're shaped the way they are.
+
+These are written for someone who needs to change a subsystem and wants to understand its design before touching it. They sit between the API docs in `docs/src/` (which describe *what* to call) and the code comments (which describe *this* function).
+
+## What belongs here
+
+An architecture note is valuable when a subsystem would take a long time to understand just from the code. If you would benefit from a whiteboarding session with a teammate to come up-to-speed on a system, that whiteboarding session should become an architecture note.
+
+## What doesn't
+
+- API reference — that goes in `docs/src/`, where Sphinx renders it.
+- Per-function behavior — that goes in docstrings.
+- Point-in-time status: migration progress, who's working on what, review state. Notes should stay true after the work lands.
+- General "PR description". Testing methodology, known shortcomings, etc.
+
+## Conventions
+
+- One file per subsystem, named after it (`graph_annotation.md`, not `annotation_v2_notes.md`).
+- Lead with the motivation. If a concrete bug or radar drove the design, name it and show the failure — that's usually the fastest way to make the rest make sense.
+- Describe the system as it is, in present tense. Don't narrate its history: no "previously", no "an earlier revision", no "the old code", no diff against a past implementation.
+- Where a design decision only makes sense against the alternative, state the alternative as a *hypothetical* rather than as a predecessor: "a lattice join is tempting, but it would override user config" reads the same and stays true regardless of what shipped when.
+- Only reference code directly when necessary. Architecture notes are deliberately high-level.
+
+## Index
+
+- [Graph Annotation](graph_annotation.md) — how a `QuantizerConfig` becomes per-node `QuantizationAnnotation` entries on an exported fx graph, by reconciling competing constraints on each tensor to a fixed point.

--- a/docs/architecture_notes/graph_annotation.md
+++ b/docs/architecture_notes/graph_annotation.md
@@ -1,0 +1,92 @@
+# Graph Annotation
+
+This note explains how graph-mode quantization annotation works: how a `QuantizerConfig` becomes a set of `QuantizationAnnotation` entries on an exported fx graph, and why the algorithm is shaped the way it is.
+
+Code lives in `src/coreai_opt/quantization/_graph/`. The entry point is `_qspec_reconcile.py`'s `annotate_via_reconciliation`, called from `_AnnotationHandler.annotate`.
+
+## Problem Formulation
+
+A quantization config allows the user to express how each quantizable tensor in the graph (weight or activation) should be quantized. However, many tensors are implicitly referred to by multiple nodes. For example, the output of a node becomes the input to another node. If both nodes independently quantized their respective references, we would end up with a quant -> dequant -> quant, even if that output is only consumed in one place. Ideally, we would quantize the tensor only once.
+
+Furthermore, passthrough operations, like `concat`, imply some agreement between their outputs and all of their inputs. In the case of `concat`, all inputs should have the same dtype and, if the output has per-tensor scales, we should jointly compute the scale and zero point across all inputs. A motivating example in pseudo-code:
+
+```text
+x = concat(conv(a), sigmoid(b))
+```
+
+Here each input to the concat has a different range. Independently, `conv(a)` would compute its range from training data, while `sigmoid(b)` would use a fixed (0, 1) range. However, because they're used in the same `concat`, we want to jointly quantize them. Thus, we should use the range of `conv(a)` even for `sigmoid(b)`.
+
+We want to ensure that the actual annotations written to the graph obey the user's intent (or communicate when we cannot obey the user's intent), while complying with the constraints that the graph imposes on shared tensors.
+
+## Constraint-relaxing algorithm
+
+1. Pattern match the graph against the config to get a ranked list of matched patterns, higher-priority configs earlier.
+2. Use the ranked patterns to construct a *provisional* qspec for each quantizable tensor, stored in the provisional qspec map. A provisional qspec answers "what would this tensor's qspec be if it didn't need to worry about any other tensor?"
+3. Find the relationships between tensors and generate a *constraints* for each. Enqueue them.
+4. While the queue is not empty:
+   1. Pop the next constraint. Fetch the provisional qspecs it references. If they already satisfy it, do nothing.
+   2. Otherwise reconcile them, field by field — see [Per-field policies](#per-field-policies).
+   3. If the constraint requires the tensors to share a *quantizer* rather than merely compatible settings, point all of them at one shared provisional qspec.
+   4. If anything changed, re-generate constraints for the affected tensors and re-enqueue.
+5. Reassemble a spec from each settled field map and annotate the graph.
+
+### Why it terminates
+
+Most constraints only ever *relax* a field or *raise* its priority-ness, and priority-ness is monotonic — reconciliation lowers a field's priority number and never raises it. We will only enqueue new constraints when a field actually changes.
+
+`InheritFields` is the exception: it copies values at unchanged priority. It terminates because the relation follows fx edges and an fx graph is a DAG, so a chain cannot cycle back on itself. Thus, there is a limit on the number of `InheritFields` constraints we can create.
+
+Empirically, we measured that constraint reconciliation takes `O(#edges)` iterations, with a constant close to 2.
+
+## Per-field policies
+
+The fields are exactly the settable inputs of `coreai_opt...QuantizationSpec`, plus `QUANTIZATION_TARGET`. Reconciliation settles each independently and `_qspec_resolution._build_concrete_spec` reassembles a spec from the results.
+
+`_qspec_constraints._FIELD_POLICY` is the authority. The reasoning:
+
+| Field | Policy | Why |
+| --- | --- | --- |
+| `DTYPE` | Highest-priority proposal wins | Two tensors sharing an observer can't have different dtypes, and there's no safe join — int4 and int8 aren't compatible in either direction. Config precedence decides. |
+| `QFORMULATION`, `FAKE_QUANTIZE_CLS`, `QPARAM_CALCULATOR_CLS`, `RANGE_CALCULATOR_CLS`, `SCALE_DTYPE`, `QSCHEME`, `GRANULARITY` | Highest-priority proposal wins | Ordinary config choices. |
+| `FLOAT_RANGE` | Widest of the proposals, per bound | A shared observer must cover every member's data, so a pin survives only while every member agrees on it. Priority is deliberately not consulted: covering the data is a correctness constraint, not a preference. This is also where "fixed qparams" lives — a fixed observer is one whose `float_range` is pinned on both bounds. |
+| `QUANTIZATION_TARGET` | Highest-priority proposal wins | This is not actually set as part of the config, but comes from whether the tensor is a weight or an activation. If we share a qspec between a weight and an activation, using the higher-priority one creates a coherent set of fields that matches at least one target's original provisional qspec. |
+
+Some properties are deliberately *not* fields. `quant_min` / `quant_max` / `n_bits` / `target_dtype` are computed by `QuantizationSpec` from `dtype` and `qscheme`, so they fall out of reassembly; reconciling them alongside their own inputs would let them contradict those inputs. `ch_axis` lives inside `GRANULARITY`.
+
+## Constraint Types
+
+Tensors can be related in a few different ways, and they need different treatment.
+
+The first is **two tensors forced onto one observer** — `cat`'s inputs, or the several consumers of one shared weight. Here the single observer has to cover every member's data, so the members' settings must be reconciled: for `cat([relu(a), b])` relu's `[0, ∞)` pin is *relaxed* to cover `b`'s negatives, because keeping it would clip `b`. `ShareObserverInstance` expresses this.
+
+The second is **two tensors which must agree on some fields**. In this case, they may have different QParams, but must agree in other ways. We cover this with `ShareFields`
+
+The third is **one tensor seen at two points**, which is what a chain of shape-only ops produces. `relu -> view -> linear` has one tensor throughout: `view` changes no values, so the tensor at `linear`'s input is relu's output and is still in `[0, ∞)`. Ideally both points would share one observer, since they are measuring identical data.
+
+They cannot. A `QParamsCalculator` is bound to a single tensor rank: it caches its resolved axis on first use and sizes its running buffers to the first tensor it sees, an invariant `QParamsCalculatorBase._resolve_axis` states directly. `view`, `reshape`, `squeeze`, `unsqueeze`, `select` and `expand` all change rank, so one observer spanning them fails at runtime — and not only under per-channel granularity, since a per-tensor observer that first saw a 4-D tensor holds `[1,1,1,1]` buffers and cannot accept 3-D.
+
+So the two points keep separate, correctly-shaped observers, and what transfers between them is the *knowledge* rather than the observer. `ShareFields` is the wrong tool for that: it reconciles, and reconciliation is bidirectional, so a downstream slot's default range would widen the upstream pin instead of adopting it. What is needed is a one-way copy, which is `InheritFields`:
+
+| Constraint | Relation | Effect |
+| --- | --- | --- |
+| `ShareObserverInstance` | different tensors, one observer | reconcile — the observer must cover every member |
+| `ShareFields` | different tensors, separate observers | agree on the named fields, nothing else |
+| `InheritFields` | one tensor, separate observers | copy, upstream to downstream |
+
+Without it, `linear`'s input relearns a range it was already given and quantizes provably non-negative data as symmetric, spending half the integer range on values that cannot occur.
+
+`InheritFields` carries only `QSCHEME` and `FLOAT_RANGE` — properties that are facts about the data rather than choices about it. `DTYPE` is excluded: it is a config choice, and copying it downstream would override a higher-priority config.
+
+Propagation resolves chain-wise rather than hop-wise. The intermediate shape-only ops aren't quantizable patterns, so they're absent from `winning_configs` and hold no fields, leaving nothing to carry a fact from one hop to the next.
+
+## Declined slots
+
+A slot is *declined* when a key in the config named it and held `None`. The referencing node does not want to quantize the tensor, but the tensor may still be quantized by other references.
+
+What a decline does then depends on which relation it lands in.
+
+**Adjacent edges drop the constraint.** An edge is one tensor with two slots. If the producer is declined while the consumer wants its input quantized, there is nothing to deduplicate: the consumer observes, the producer doesn't, and the edge carries one observer either way.
+
+**Groups tied by op semantics let quantization win.** For `flatten`, `cat`, `maxpool` and the rank-preserving shape-only ops, the tied slots are one tensor of one op. "Quantize my input but not my output" is not a coherent instruction about such a tensor, so any member asking to be observed outranks a decline, in either direction, whatever the priorities. The group goes unobserved only when nothing in it asks for quantization — which is what makes a weight-only config leave every `flatten` and `cat` in float, since there both sides are disabled.
+
+**Shared state resolves by priority.** One weight reached by several consumers is also one tensor, but each consumer's config independently states whether *it* quantizes, so ordinary config precedence applies and the highest-priority proposal decides — decline or not. This is what lets `op_name_config` exclude a single invocation of a reused module: that entry outranks the global config, so its `None` wins and the shared weight goes unobserved. Ties go to the decline.

--- a/docs/architecture_notes/graph_annotation.md
+++ b/docs/architecture_notes/graph_annotation.md
@@ -44,12 +44,12 @@ The fields are exactly the settable inputs of `coreai_opt...QuantizationSpec`, p
 
 `_qspec_constraints._FIELD_POLICY` is the authority. The reasoning:
 
-| Field | Policy | Why |
-| --- | --- | --- |
-| `DTYPE` | Highest-priority proposal wins | Two tensors sharing an observer can't have different dtypes, and there's no safe join — int4 and int8 aren't compatible in either direction. Config precedence decides. |
-| `QFORMULATION`, `FAKE_QUANTIZE_CLS`, `QPARAM_CALCULATOR_CLS`, `RANGE_CALCULATOR_CLS`, `SCALE_DTYPE`, `QSCHEME`, `GRANULARITY` | Highest-priority proposal wins | Ordinary config choices. |
-| `FLOAT_RANGE` | Widest of the proposals, per bound | A shared observer must cover every member's data, so a pin survives only while every member agrees on it. Priority is deliberately not consulted: covering the data is a correctness constraint, not a preference. This is also where "fixed qparams" lives — a fixed observer is one whose `float_range` is pinned on both bounds. |
-| `QUANTIZATION_TARGET` | Highest-priority proposal wins | This is not actually set as part of the config, but comes from whether the tensor is a weight or an activation. If we share a qspec between a weight and an activation, using the higher-priority one creates a coherent set of fields that matches at least one target's original provisional qspec. |
+| Field                                                                                                                         | Policy                             | Why                                                                                                                                                                                                                                                                                                                                 |
+| ----------------------------------------------------------------------------------------------------------------------------- | ---------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `DTYPE`                                                                                                                       | Highest-priority proposal wins     | Two tensors sharing an observer can't have different dtypes, and there's no safe join — int4 and int8 aren't compatible in either direction. Config precedence decides.                                                                                                                                                             |
+| `QFORMULATION`, `FAKE_QUANTIZE_CLS`, `QPARAM_CALCULATOR_CLS`, `RANGE_CALCULATOR_CLS`, `SCALE_DTYPE`, `QSCHEME`, `GRANULARITY` | Highest-priority proposal wins     | Ordinary config choices.                                                                                                                                                                                                                                                                                                            |
+| `FLOAT_RANGE`                                                                                                                 | Widest of the proposals, per bound | A shared observer must cover every member's data, so a pin survives only while every member agrees on it. Priority is deliberately not consulted: covering the data is a correctness constraint, not a preference. This is also where "fixed qparams" lives — a fixed observer is one whose `float_range` is pinned on both bounds. |
+| `QUANTIZATION_TARGET`                                                                                                         | Highest-priority proposal wins     | This is not actually set as part of the config, but comes from whether the tensor is a weight or an activation. If we share a qspec between a weight and an activation, using the higher-priority one creates a coherent set of fields that matches at least one target's original provisional qspec.                               |
 
 Some properties are deliberately *not* fields. `quant_min` / `quant_max` / `n_bits` / `target_dtype` are computed by `QuantizationSpec` from `dtype` and `qscheme`, so they fall out of reassembly; reconciling them alongside their own inputs would let them contradict those inputs. `ch_axis` lives inside `GRANULARITY`.
 
@@ -67,11 +67,11 @@ They cannot. A `QParamsCalculator` is bound to a single tensor rank: it caches i
 
 So the two points keep separate, correctly-shaped observers, and what transfers between them is the *knowledge* rather than the observer. `ShareFields` is the wrong tool for that: it reconciles, and reconciliation is bidirectional, so a downstream slot's default range would widen the upstream pin instead of adopting it. What is needed is a one-way copy, which is `InheritFields`:
 
-| Constraint | Relation | Effect |
-| --- | --- | --- |
-| `ShareObserverInstance` | different tensors, one observer | reconcile — the observer must cover every member |
-| `ShareFields` | different tensors, separate observers | agree on the named fields, nothing else |
-| `InheritFields` | one tensor, separate observers | copy, upstream to downstream |
+| Constraint              | Relation                              | Effect                                           |
+| ----------------------- | ------------------------------------- | ------------------------------------------------ |
+| `ShareObserverInstance` | different tensors, one observer       | reconcile — the observer must cover every member |
+| `ShareFields`           | different tensors, separate observers | agree on the named fields, nothing else          |
+| `InheritFields`         | one tensor, separate observers        | copy, upstream to downstream                     |
 
 Without it, `linear`'s input relearns a range it was already given and quantizes provably non-negative data as symmetric, spending half the integer range on values that cannot occur.
 

--- a/src/coreai_opt/_utils/config_utils.py
+++ b/src/coreai_opt/_utils/config_utils.py
@@ -19,6 +19,18 @@ logger = logging.getLogger(__name__)
 ALL_TENSORS = "*"
 
 
+def spec_dict_is_active(spec_dict: Mapping[Any, Any] | None) -> bool:
+    """Whether ``spec_dict`` asks for compression on any tensor.
+
+    ``{}`` and ``{"*": None}`` are both inactive. Consumers that care about the
+    difference — "no opinion" vs "explicitly disabled" — should inspect the dict
+    directly; this only answers whether anything is being compressed.
+    """
+    if not spec_dict:
+        return False
+    return any(spec is not None for spec in spec_dict.values())
+
+
 def get_last_matching_spec(
     identifiers: Iterable[int | str],
     spec_dict: Mapping[int | str, Any],

--- a/src/coreai_opt/config/compression_config.py
+++ b/src/coreai_opt/config/compression_config.py
@@ -26,7 +26,11 @@ from pydantic import (
     model_validator,
 )
 
-from coreai_opt._utils.config_utils import ConfigLevel as _ConfigLevel
+from coreai_opt._utils.config_utils import (
+    ALL_TENSORS as _ALL_TENSORS,
+    ConfigLevel as _ConfigLevel,
+    spec_dict_is_active as _spec_dict_is_active,
+)
 from coreai_opt._utils.python_utils import (
     fqn as _fqn,
     get_generic_type_arg as _get_generic_type_arg,
@@ -38,6 +42,19 @@ def _convert_none_to_empty_dict(v: Any):
     """If v is None, return an empty dict. Return v otherwise."""
     if v is None:
         return {}
+    return v
+
+
+def _convert_none_to_disabled_spec_dict(v: Any):
+    """If v is None, return ``{"*": None}``. Return v otherwise.
+
+    For spec dicts, ``None`` means "compress nothing here", which is the same
+    thing ``{"*": None}`` says explicitly. Normalizing to the explicit form keeps
+    the disabling at the tensor level, so a consumer can tell it apart from ``{}``
+    — a dict that names no tensor and therefore expresses no opinion.
+    """
+    if v is None:
+        return {_ALL_TENSORS: None}
     return v
 
 
@@ -103,16 +120,16 @@ class OpCompressionConfig(BaseModel, ABC, Generic[_SpecT]):
 
     op_input_spec: Annotated[
         dict[str | int, _SpecT | None] | None,
-        BeforeValidator(_convert_none_to_empty_dict),
+        BeforeValidator(_convert_none_to_disabled_spec_dict),
         BeforeValidator(_convert_digit_str_keys_to_int),
     ]
     op_output_spec: Annotated[
         dict[str | int, _SpecT | None] | None,
-        BeforeValidator(_convert_none_to_empty_dict),
+        BeforeValidator(_convert_none_to_disabled_spec_dict),
         BeforeValidator(_convert_digit_str_keys_to_int),
     ]
     op_state_spec: Annotated[
-        dict[str, _SpecT | None] | None, BeforeValidator(_convert_none_to_empty_dict)
+        dict[str, _SpecT | None] | None, BeforeValidator(_convert_none_to_disabled_spec_dict)
     ]
 
     @classmethod
@@ -166,8 +183,9 @@ class OpCompressionConfig(BaseModel, ABC, Generic[_SpecT]):
         This validator runs before field validation and applies the default specs
         defined by subclasses if the specs are not provided in the input data.
 
-        Note: Explicitly passing None will result in an empty dict (via BeforeValidator)
-        while omitting the field entirely will apply defaults.
+        Note: Explicitly passing None disables the category (it becomes
+        ``{"*": None}`` via BeforeValidator) while omitting the field entirely
+        applies defaults.
         """
         if not isinstance(data, dict):
             return data
@@ -223,9 +241,9 @@ class WeightOnlyOpValidationMixin:
             f"{self.__class__.__name__} does not support {{key}}. "
             f"This is a weight-only compression type that only supports op_state_spec."
         )
-        if self.op_input_spec:
+        if _spec_dict_is_active(self.op_input_spec):
             raise ValueError(error_msg.format(key="op_input_spec"))
-        if self.op_output_spec:
+        if _spec_dict_is_active(self.op_output_spec):
             raise ValueError(error_msg.format(key="op_output_spec"))
         return self
 
@@ -283,16 +301,16 @@ class ModuleCompressionConfig(BaseModel, Generic[_OpConfigT, _SpecT]):
 
     op_input_spec: Annotated[
         dict[str | int, _SpecT | None] | None,
-        BeforeValidator(_convert_none_to_empty_dict),
+        BeforeValidator(_convert_none_to_disabled_spec_dict),
         BeforeValidator(_convert_digit_str_keys_to_int),
     ]
     op_output_spec: Annotated[
         dict[str | int, _SpecT | None] | None,
-        BeforeValidator(_convert_none_to_empty_dict),
+        BeforeValidator(_convert_none_to_disabled_spec_dict),
         BeforeValidator(_convert_digit_str_keys_to_int),
     ]
     op_state_spec: Annotated[
-        dict[str, _SpecT | None] | None, BeforeValidator(_convert_none_to_empty_dict)
+        dict[str, _SpecT | None] | None, BeforeValidator(_convert_none_to_disabled_spec_dict)
     ]
     op_type_config: Annotated[
         dict[str, _OpConfigT | None] | None, BeforeValidator(_convert_none_to_empty_dict)
@@ -332,8 +350,9 @@ class ModuleCompressionConfig(BaseModel, Generic[_OpConfigT, _SpecT]):
 
         Gets default specs from the _OpConfigT type parameter's default methods.
 
-        Note: Explicitly passing None will result in an empty dict (via BeforeValidator)
-        while omitting the field entirely will apply defaults.
+        Note: Explicitly passing None disables the category (it becomes
+        ``{"*": None}`` via BeforeValidator) while omitting the field entirely
+        applies defaults.
         """
         if not isinstance(data, dict):
             return data
@@ -354,7 +373,8 @@ class ModuleCompressionConfig(BaseModel, Generic[_OpConfigT, _SpecT]):
         """Replace None values in op_type_config/op_name_config with disabled configs.
 
         A None value means "disable compression for this op type/name". This
-        validator normalises it to an explicit OpConfig with empty specs.
+        validator normalises it to an explicit OpConfig whose every spec category
+        is disabled.
         """
         op_config_cls = self._get_op_config_class()
         if op_config_cls is None:
@@ -421,13 +441,13 @@ class WeightOnlyModuleValidationMixin:
             f"This is a weight-only compression type that only supports "
             f"op_state_spec and module_state_spec."
         )
-        if self.op_input_spec:
+        if _spec_dict_is_active(self.op_input_spec):
             raise ValueError(error_msg.format(key="op_input_spec"))
-        if self.op_output_spec:
+        if _spec_dict_is_active(self.op_output_spec):
             raise ValueError(error_msg.format(key="op_output_spec"))
-        if self.module_input_spec:
+        if _spec_dict_is_active(self.module_input_spec):
             raise ValueError(error_msg.format(key="module_input_spec"))
-        if self.module_output_spec:
+        if _spec_dict_is_active(self.module_output_spec):
             raise ValueError(error_msg.format(key="module_output_spec"))
         return self
 

--- a/src/coreai_opt/quantization/_graph/_annotation_config.py
+++ b/src/coreai_opt/quantization/_graph/_annotation_config.py
@@ -5,10 +5,9 @@
 
 from __future__ import annotations
 
-from collections.abc import Mapping, Set
+from collections.abc import Mapping
 from dataclasses import dataclass
 
-import torch.fx
 from torchao.quantization.pt2e.quantizer import (
     QuantizationSpec as TorchAOQuantizationSpec,
 )
@@ -35,12 +34,9 @@ class AnnotationContext:
             list of local names the module uses for that state. Used during
             state-input annotation to translate a state node's target into the
             consumer module's local name(s).
-        shared_observer_nodes (Set[torch.fx.Node]): Nodes whose output annotations
-            are shared with their input annotations if any.
     """
 
     module_name_to_state_names_map: Mapping[str, Mapping[str, list[str]]]
-    shared_observer_nodes: Set[torch.fx.Node]
 
 
 class AnnotationConfig:

--- a/src/coreai_opt/quantization/_graph/_annotation_pattern_registry.py
+++ b/src/coreai_opt/quantization/_graph/_annotation_pattern_registry.py
@@ -4,10 +4,9 @@
 # be found in the LICENSE file or at https://opensource.org/licenses/BSD-3-Clause
 
 from abc import ABC, abstractmethod
-from collections.abc import Callable
 from copy import deepcopy
 from dataclasses import dataclass
-from typing import Any, Generic, TypeAlias, TypeVar
+from typing import Generic, TypeVar
 
 import torch
 from torch.fx.passes.utils.matcher_utils import InternalMatch
@@ -16,37 +15,38 @@ from torch.fx.passes.utils.source_matcher_utils import SourcePartition
 from coreai_opt._utils.registry_utils import ClassRegistryMixin
 
 from . import _annotation_utils
-from ._annotation_config import AnnotationConfig, AnnotationContext
 from ._annotation_utils import OpsListPattern
+from ._qspec_constraints import (
+    Constraint,
+    ShareFields,
+    ShareObserverInstance,
+)
+from ._qspec_types import (
+    FieldName,
+    NodeSlot,
+    ProvisionalQSpec,
+    ProvisionalQSpecMap,
+    SlotKind,
+)
 
 # Generic type variable for match results
 MatchType = TypeVar("MatchType")
 
-# Generic annotator function type.
-# The function is expected to take exactly 3 inputs:
-# 1. Matched nodes to annotate. The type of this entity is flexible depending
-#    on the implementation of the AnnotationPattern subclass. Whatever entity
-#    is returned in the subclass's match_single_pattern dictionary values will
-#    be passed into this function as the first input.
-# 2. Quantization Config to use when annotating the matched nodes (per-match,
-#    derived from OpQuantizerConfig).
-# 3. Annotation pass context. Holds pass-invariant inputs the annotator may
-#    need (the model's module-name-to-state-names map and the set of shared
-#    observer nodes computed at the start of this annotation pass).
-AnnotatorFunc: TypeAlias = Callable[[MatchType, AnnotationConfig, AnnotationContext], Any]
+# A pattern node of any other kind is an op the pattern spans, which is what both
+# get_pattern_length and _nodes_covered_by count.
+_OPERAND_NODE_OPS = frozenset({"get_attr", "placeholder", "output"})
 
 
 @dataclass(frozen=True)
 class AnnotatorMatchInfo(Generic[MatchType]):
-    """
-    Holds info related to nodes matched with a particular annotator.
+    """Info about a single annotator's match on the graph.
 
-    annotator_func: A function used to annotate nodes in annotator_match
-    annotator_match: Nodes in the model matched with the annotator
-    pattern_length: Length of the annotation pattern
+    Attributes:
+        annotator_match (MatchType): Nodes in the model matched with the
+            annotator.
+        pattern_length (int): Length of the annotation pattern.
     """
 
-    annotator_func: AnnotatorFunc[MatchType]
     annotator_match: MatchType
     pattern_length: int
 
@@ -83,8 +83,6 @@ class BaseAnnotationPattern(Generic[MatchType], ABC):
     Base class for annotation patterns.
 
     Each pattern class should implement:
-    - get_annotator_func(): Returns a function used to annotate nodes in accordance with
-                            the Annotation pattern.
     - generate_patterns(): Returns list of graph modules representing
                            the patterns to match
     - match_single_pattern(): Matches graph for a single pattern
@@ -92,18 +90,6 @@ class BaseAnnotationPattern(Generic[MatchType], ABC):
 
     # Class-level cache for patterns
     _patterns: list[torch.fx.GraphModule | OpsListPattern] | None = None
-
-    @classmethod
-    @abstractmethod
-    def get_annotator_func(cls) -> AnnotatorFunc[MatchType]:
-        """
-        Return a function which is used to annotate nodes in accordance with a
-        particular Annotation pattern.
-
-        Returns:
-            Function used to annotate nodes.
-        """
-        raise NotImplementedError
 
     @classmethod
     def get_patterns(cls) -> list[torch.fx.GraphModule | OpsListPattern]:
@@ -153,7 +139,7 @@ class BaseAnnotationPattern(Generic[MatchType], ABC):
                 "call_method",
                 "call_module",
             ]
-            if node.op not in ["get_attr", "placeholder", "output"]:
+            if node.op not in _OPERAND_NODE_OPS:
                 pattern_len += 1
         return pattern_len
 
@@ -170,7 +156,7 @@ class BaseAnnotationPattern(Generic[MatchType], ABC):
         Generate the patterns for this annotator. Called once and cached.
 
         Returns:
-            List of torch.fx.GraphModule or _OpsListPattern objects representing
+            List of torch.fx.GraphModule or OpsListPattern objects representing
             different patterns
         """
         pass
@@ -186,7 +172,7 @@ class BaseAnnotationPattern(Generic[MatchType], ABC):
 
         Args:
             model (torch.fx.GraphModule): Exported GraphModule model to match
-            pattern (torch.fx.GraphModule | _OpsListPattern): Pattern used to match
+            pattern (torch.fx.GraphModule | OpsListPattern): Pattern used to match
 
         Returns:
             dict[torch.fx.Node, MatchType]: Dictionary mapping nodes to matches.
@@ -234,7 +220,6 @@ class BaseAnnotationPattern(Generic[MatchType], ABC):
                 {
                     node: AnnotatorMatchInfo(
                         pattern_length=cls.get_pattern_length(),
-                        annotator_func=cls.get_annotator_func(),
                         annotator_match=match,
                     )
                     for node, match in node_to_match_dict.items()
@@ -258,14 +243,6 @@ class WeightedModulePattern(BaseAnnotationPattern[InternalMatch]):
     Where batch_norm and activation are optional components that may or may not
     be present in the pattern.
     """
-
-    @classmethod
-    def get_annotator_func(cls) -> AnnotatorFunc[InternalMatch]:
-        """
-        Return a function which is used to annotate nodes in accordance with
-        WeightedModulePattern.
-        """
-        return _annotation_utils.annotate_weighted_mod_match
 
     @classmethod
     def match_single_pattern(
@@ -306,14 +283,6 @@ class NAryActPattern(BaseAnnotationPattern[tuple[SourcePartition]]):
     """
 
     @classmethod
-    def get_annotator_func(cls) -> AnnotatorFunc[tuple[SourcePartition]]:
-        """
-        Return a function which is used to annotate nodes in accordance with
-        NAryActPattern.
-        """
-        return _annotation_utils.annotate_n_ary_act_match
-
-    @classmethod
     def match_single_pattern(
         cls, model: torch.fx.GraphModule, pattern: torch.fx.GraphModule | OpsListPattern
     ) -> dict[torch.fx.Node, tuple[SourcePartition]]:
@@ -323,7 +292,7 @@ class NAryActPattern(BaseAnnotationPattern[tuple[SourcePartition]]):
         """
         if not isinstance(pattern, OpsListPattern):
             error_msg = (
-                "NAryActPattern expects patterns of type _OpsListPattern, but "
+                "NAryActPattern expects patterns of type OpsListPattern, but "
                 f"got type {type(pattern)}.)"
             )
             raise RuntimeError(error_msg)
@@ -344,15 +313,31 @@ class SharedObserverModulePattern(BaseAnnotationPattern[tuple[SourcePartition]])
 
     Subclasses must implement the generate_patterns() method to define the
     specific patterns they want to match (e.g., maxpool, avgpool, flatten, etc.).
+
+    Subclasses must implement :meth:`generate_qspec_sharing_constraints` to
+    declare how specs are shared across the op's input and output slots.
     """
 
     @classmethod
-    def get_annotator_func(cls) -> AnnotatorFunc[tuple[SourcePartition]]:
+    @abstractmethod
+    def generate_qspec_sharing_constraints(
+        cls,
+        node: torch.fx.Node,
+        qspecs: ProvisionalQSpecMap,
+    ) -> list[Constraint]:
+        """Return the constraints binding this op's input and output slots.
+
+        Called once per matched node, and may inspect the current state — concat's
+        decision depends on the output slot's granularity.
+
+        Args:
+            node (torch.fx.Node): The matched op node.
+            qspecs (ProvisionalQSpecMap): Current state.
+
+        Returns:
+            list[Constraint]: Empty means this op enforces no sharing.
         """
-        Return a function which is used to annotate nodes in accordance with
-        SharedObserverModulePattern.
-        """
-        return _annotation_utils.annotate_shared_observer_match
+        raise NotImplementedError
 
     @classmethod
     def _validate_patterns_length(cls):
@@ -376,11 +361,31 @@ class SharedObserverModulePattern(BaseAnnotationPattern[tuple[SourcePartition]])
         if not isinstance(pattern, OpsListPattern):
             error_msg = (
                 "SharedObserverModulePattern expects patterns of type "
-                f"_OpsListPattern, but got type {type(pattern)}.)"
+                f"OpsListPattern, but got type {type(pattern)}.)"
             )
             raise RuntimeError(error_msg)
 
         return _annotation_utils.match_pattern_with_sequential_partitions(model, pattern)
+
+
+def _shared_op_boundary_slots(node: torch.fx.Node) -> tuple[NodeSlot, list[NodeSlot]]:
+    """Return the output slot and the input slots on a shared-observer node."""
+    output_slot = NodeSlot(node=node, kind=SlotKind.OUTPUT, arg_index=0)
+    input_slots = [
+        NodeSlot(node=node, kind=SlotKind.INPUT, arg_index=arg_index)
+        for arg_index in range(len(node.all_input_nodes))
+    ]
+    return output_slot, input_slots
+
+
+def _any_input_slot_populated(
+    input_slots: list[NodeSlot], qspecs: ProvisionalQSpecMap
+) -> bool:
+    """Whether any input slot has a proposal yet.
+
+    With none, there is nothing for the sharing to enforce.
+    """
+    return any(input_slot in qspecs for input_slot in input_slots)
 
 
 class _AnnotationPatternRegistry(ClassRegistryMixin):
@@ -782,6 +787,13 @@ class FlattenPattern(SharedObserverModulePattern):
         """Returns flatten pattern."""
         return _get_all_patterns_from_base_ops({"flatten"})
 
+    @classmethod
+    def generate_qspec_sharing_constraints(
+        cls, node: torch.fx.Node, qspecs: ProvisionalQSpecMap
+    ) -> list[Constraint]:
+        """All slots share one observer instance — flatten preserves values."""
+        return _all_slots_share_observer(node, qspecs)
+
 
 @_AnnotationPatternRegistry.register("maxpool")
 class MaxPoolPattern(SharedObserverModulePattern):
@@ -799,6 +811,13 @@ class MaxPoolPattern(SharedObserverModulePattern):
                 "max_pool3d",
             }
         )
+
+    @classmethod
+    def generate_qspec_sharing_constraints(
+        cls, node: torch.fx.Node, qspecs: ProvisionalQSpecMap
+    ) -> list[Constraint]:
+        """All slots share one observer instance — maxpool preserves values."""
+        return _all_slots_share_observer(node, qspecs)
 
 
 @_AnnotationPatternRegistry.register("avgpool")
@@ -822,6 +841,13 @@ class AvgPoolPattern(SharedObserverModulePattern):
             }
         )
 
+    @classmethod
+    def generate_qspec_sharing_constraints(
+        cls, node: torch.fx.Node, qspecs: ProvisionalQSpecMap
+    ) -> list[Constraint]:
+        """All slots share one observer instance — averaging preserves range roughly."""
+        return _all_slots_share_observer(node, qspecs)
+
 
 @_AnnotationPatternRegistry.register("concat")
 class ConcatPattern(SharedObserverModulePattern):
@@ -833,3 +859,85 @@ class ConcatPattern(SharedObserverModulePattern):
     def generate_patterns(cls) -> list[torch.fx.GraphModule]:
         """Returns concat pattern."""
         return _get_all_patterns_from_base_ops({"cat", "concat"})
+
+    @classmethod
+    def generate_qspec_sharing_constraints(
+        cls, node: torch.fx.Node, qspecs: ProvisionalQSpecMap
+    ) -> list[Constraint]:
+        """Inputs must observe together unless the output is per-channel along the
+        concat axis, in which case each keeps its own scale and they need only
+        agree on ``DTYPE``.
+        """
+        output_slot, input_slots = _shared_op_boundary_slots(node)
+        if not _any_input_slot_populated(input_slots, qspecs):
+            return []
+
+        all_slots = frozenset([output_slot, *input_slots])
+
+        concat_dim = _concat_dim(node)
+        output_fields = qspecs.get(output_slot, ProvisionalQSpec()).fields
+        output_granularity = output_fields.get(FieldName.GRANULARITY)
+
+        # A per-tensor granularity has ``axis is None``.
+        granularity_axis = (
+            output_granularity.value.axis if output_granularity is not None else None
+        )
+        per_channel_along_concat_axis = (
+            granularity_axis is not None
+            and _same_axis(granularity_axis, concat_dim, node)
+        )
+        if not per_channel_along_concat_axis:
+            # Sharing an instance subsumes sharing fields, since the merged group
+            # reconciles all of them.
+            return [ShareObserverInstance(_slots=all_slots)]
+
+        # Each input keeps its own scale, so they need only agree on the
+        # axis-independent fields.
+        return [ShareFields(_slots=all_slots, fields=frozenset({FieldName.DTYPE}))]
+
+
+def _all_slots_share_observer(
+    node: torch.fx.Node, qspecs: ProvisionalQSpecMap
+) -> list[Constraint]:
+    """Tie every input and output slot into one observer instance.
+
+    For shared-observer ops whose sharing doesn't depend on any spec field.
+    """
+    output_slot, input_slots = _shared_op_boundary_slots(node)
+    if not _any_input_slot_populated(input_slots, qspecs):
+        return []
+    return [ShareObserverInstance(_slots=frozenset([output_slot, *input_slots]))]
+
+
+def _concat_dim(node: torch.fx.Node) -> int:
+    """Concat dim from ``aten.cat(tensors, dim=?)``, defaulting to 0.
+
+    As written on the node, so possibly negative — ``torch.export`` does not
+    normalize it. Compare with :func:`_same_axis`.
+    """
+    if len(node.args) >= 2:
+        return int(node.args[1])
+    return int(node.kwargs.get("dim", 0))
+
+
+def _same_axis(ch_axis: int, concat_dim: int, node: torch.fx.Node) -> bool:
+    """Whether ``ch_axis`` and ``concat_dim`` name the same dimension.
+
+    They need not agree on sign — for a rank-4 output ``1`` and ``-3`` are one
+    dimension. Falls back to exact comparison without tensor metadata.
+    """
+    if ch_axis == concat_dim:
+        return True
+    rank = _output_tensor_rank(node)
+    if rank is None:
+        return False
+    return ch_axis % rank == concat_dim % rank
+
+
+def _output_tensor_rank(node: torch.fx.Node) -> int | None:
+    """Rank of ``node``'s output tensor from fx metadata, or ``None``."""
+    val = node.meta.get("val")
+    shape = getattr(val, "shape", None)
+    if shape is None:
+        return None
+    return len(shape)

--- a/src/coreai_opt/quantization/_graph/_annotation_pattern_registry.py
+++ b/src/coreai_opt/quantization/_graph/_annotation_pattern_registry.py
@@ -378,9 +378,7 @@ def _shared_op_boundary_slots(node: torch.fx.Node) -> tuple[NodeSlot, list[NodeS
     return output_slot, input_slots
 
 
-def _any_input_slot_populated(
-    input_slots: list[NodeSlot], qspecs: ProvisionalQSpecMap
-) -> bool:
+def _any_input_slot_populated(input_slots: list[NodeSlot], qspecs: ProvisionalQSpecMap) -> bool:
     """Whether any input slot has a proposal yet.
 
     With none, there is nothing for the sharing to enforce.
@@ -879,12 +877,9 @@ class ConcatPattern(SharedObserverModulePattern):
         output_granularity = output_fields.get(FieldName.GRANULARITY)
 
         # A per-tensor granularity has ``axis is None``.
-        granularity_axis = (
-            output_granularity.value.axis if output_granularity is not None else None
-        )
-        per_channel_along_concat_axis = (
-            granularity_axis is not None
-            and _same_axis(granularity_axis, concat_dim, node)
+        granularity_axis = output_granularity.value.axis if output_granularity is not None else None
+        per_channel_along_concat_axis = granularity_axis is not None and _same_axis(
+            granularity_axis, concat_dim, node
         )
         if not per_channel_along_concat_axis:
             # Sharing an instance subsumes sharing fields, since the merged group
@@ -896,9 +891,7 @@ class ConcatPattern(SharedObserverModulePattern):
         return [ShareFields(_slots=all_slots, fields=frozenset({FieldName.DTYPE}))]
 
 
-def _all_slots_share_observer(
-    node: torch.fx.Node, qspecs: ProvisionalQSpecMap
-) -> list[Constraint]:
+def _all_slots_share_observer(node: torch.fx.Node, qspecs: ProvisionalQSpecMap) -> list[Constraint]:
     """Tie every input and output slot into one observer instance.
 
     For shared-observer ops whose sharing doesn't depend on any spec field.

--- a/src/coreai_opt/quantization/_graph/_annotation_utils.py
+++ b/src/coreai_opt/quantization/_graph/_annotation_utils.py
@@ -4,7 +4,7 @@
 # be found in the LICENSE file or at https://opensource.org/licenses/BSD-3-Clause
 
 import logging
-from collections.abc import Callable, Iterable, Mapping
+from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from typing import Any, Literal
 
@@ -21,12 +21,15 @@ from torchao.quantization.pt2e import WrapperModule, find_sequential_partitions
 from torchao.quantization.pt2e.quantizer import (
     QuantizationAnnotation,
     QuantizationSpec as TorchAOQuantizationSpec,
-    SharedQuantizationSpec as _SharedQuantizationSpec,
     get_module_name_filter,
 )
 from torchao.quantization.pt2e.quantizer.quantizer import Q_ANNOTATION_KEY
 
-from coreai_opt._utils.config_utils import ALL_TENSORS, ConfigLevel, get_last_matching_spec
+from coreai_opt._utils.config_utils import (
+    ALL_TENSORS,
+    ConfigLevel,
+    get_last_matching_spec,
+)
 from coreai_opt._utils.fx_utils import (
     get_local_state_name,
     get_module_boundary_nodes,
@@ -43,7 +46,6 @@ from coreai_opt.quantization.config.quantization_config import (
     _STATE_SPEC_DICT,
 )
 from coreai_opt.quantization.spec import (
-    QuantizationComponentFactory,
     QuantizationScheme,
     QuantizationSpec,
 )
@@ -55,27 +57,6 @@ logger = logging.getLogger(__name__)
 
 INPUT_NODE_PREFIX = "input::"
 PARAM_NODE_PREFIX = "param::"
-
-# Ops that are transparent to quantization range propagation: they don't alter
-# the numeric range of their inputs, so we traverse through them when propagating
-# adjusted qspecs to child nodes.
-_PASSTHROUGH_OP_OVERLOADS: frozenset = frozenset(
-    {
-        torch.ops.aten.clone,
-        torch.ops.aten.dropout,
-        torch.ops.aten.expand,
-        torch.ops.aten.feature_dropout,
-        torch.ops.aten.permute,
-        torch.ops.aten.reshape,
-        torch.ops.aten.select,
-        torch.ops.aten.slice,
-        torch.ops.aten.squeeze,
-        torch.ops.aten.t,
-        torch.ops.aten.transpose,
-        torch.ops.aten.unsqueeze,
-        torch.ops.aten.view,
-    }
-)
 
 
 def _get_aten_graph_module_for_pattern(
@@ -193,147 +174,6 @@ def is_node_annotated(node: Node) -> bool:
     Returns True if the node is annotated, otherwise returns False
     """
     return node and Q_ANNOTATION_KEY in node.meta and node.meta[Q_ANNOTATION_KEY]._annotated
-
-
-def is_any_annotated(nodes: list[Node]) -> bool:
-    """
-    Given a list of nodes (that represents an operator pattern),
-    check if any of the node is annotated, return True if any of the node
-    is annotated, otherwise return False.
-    """
-    return any(is_node_annotated(node) for node in nodes)
-
-
-def is_all_annotated(nodes: list[Node]) -> bool:
-    """
-    Given a list of nodes (that represents an operator pattern),
-    return True if all of the node is annotated, otherwise return False.
-    """
-    return all(is_node_annotated(node) for node in nodes)
-
-
-def mark_nodes_as_annotated(nodes: Iterable[Node]) -> None:
-    for node in nodes:
-        if node is not None:
-            if Q_ANNOTATION_KEY not in node.meta:
-                node.meta[Q_ANNOTATION_KEY] = QuantizationAnnotation()
-            node.meta[Q_ANNOTATION_KEY]._annotated = True
-
-
-def _propagate_adjusted_spec_to_child_nodes(
-    root_node: torch.fx.Node,
-    qscheme: QuantizationScheme | None,
-    float_range: tuple[float, float] | None,
-    shared_observer_nodes: set[torch.fx.Node],
-) -> None:
-    """
-    Given a qscheme or float_range, propagate the info to all applicable children. Any input qspecs
-    which are not shared qspecs will have specs updated. The propagation logic
-    continues downwards through the graph until we encounter a non-shared observer op.
-    """
-    # Set of op types for which we want to propagate the updated spec through, even though they
-    # are not registered ops with quantizers themselves.
-    # This is a temporary solution. Adding them as SharedObserverPatterns may make sense, but
-    # additional consideration is needed as to whether it makes sense to have quantizers in between
-    # multiple shared observer ops.
-    # To minimize the impact of this change to quantization behavior as a whole, use the below
-    # set to skip these ops while continuing to traverse through the graph.
-    nodes_to_propagate = [(root_node, user) for user in root_node.users.keys()]
-    while nodes_to_propagate:
-        parent, curr_node = nodes_to_propagate.pop(0)
-        if (
-            curr_node.op == "call_function"
-            and getattr(curr_node.target, "overloadpacket", None) in _PASSTHROUGH_OP_OVERLOADS
-        ):
-            assert curr_node not in shared_observer_nodes
-            nodes_to_propagate.extend([(curr_node, user) for user in curr_node.users.keys()])
-            continue
-        if not is_node_annotated(curr_node):
-            continue
-        curr_input_qspec = curr_node.meta[Q_ANNOTATION_KEY].input_qspec_map.get(parent)
-        if curr_input_qspec is None:
-            continue
-        if (
-            isinstance(curr_input_qspec, _SharedQuantizationSpec)
-            and root_node not in curr_input_qspec.edge_or_node
-        ):
-            # This is a case in which we encounter a multi input op which already has a
-            # shared input qspec referencing a different edge. Here, we will not update
-            # the qscheme since it would unnecessarily constrain the range of the other
-            # edge. Here, there is the possiblity of having back to back quantize
-            # dequantize ops inserted.
-            continue
-        if not isinstance(curr_input_qspec, _SharedQuantizationSpec):
-            ctr = curr_input_qspec.observer_or_fake_quant_ctr
-            kwargs = {}
-            if qscheme is not None:
-                kwargs["qscheme"] = qscheme
-            if float_range is not None:
-                kwargs["float_range"] = float_range
-            if kwargs:
-                ctr = QuantizationComponentFactory.reconstruct_partial_qparams_calculator(
-                    ctr, **kwargs
-                )
-
-            # qscheme in TorchAOQuantizationSpec is not read by coreai-opt later on so we omit it.
-            # Only the qscheme contained within observer_or_fake_quant_ctr matters.
-            adjusted_qspec = TorchAOQuantizationSpec(
-                observer_or_fake_quant_ctr=ctr,
-                dtype=curr_input_qspec.dtype,
-                quant_min=curr_input_qspec.quant_min,
-                quant_max=curr_input_qspec.quant_max,
-            )
-            curr_node.meta[Q_ANNOTATION_KEY].input_qspec_map[parent] = adjusted_qspec
-
-        if curr_node in shared_observer_nodes:
-            nodes_to_propagate.extend([(curr_node, user) for user in curr_node.users.keys()])
-
-
-def adjust_output_qspec_for_qscheme_and_propagate(
-    node: torch.fx.Node, shared_observer_nodes: set[torch.fx.Node]
-) -> None:
-    """
-    Adjust output quantization spec for ops which can use fixed qparams
-    or ops for which we can use affine quantization mode during
-    symmetric quantization because their output is always positive.
-    Propagate the updated qscheme to input qspecs of child ops.
-
-    Args:
-        node: The node whose output qspec should be updated if necessary
-        shared_observer_nodes: Set of shared observer nodes for which adjusted qschemes
-            should propagate through
-    """
-    if not is_node_annotated(node):
-        return
-
-    qspec = node.meta[Q_ANNOTATION_KEY].output_qspec
-    if qspec is None:
-        return
-
-    if node.target in _fixed_q_params_ops:
-        qscheme, float_range = _fixed_q_params_ops[node.target]
-    elif node.target in _hardtanh_ops:
-        min_val, max_val = node.args[1], node.args[2]
-        float_range = (min_val, max_val)
-        qscheme = (
-            QuantizationScheme.SYMMETRIC if min_val == -max_val else QuantizationScheme.ASYMMETRIC
-        )
-    else:
-        return
-
-    ctr = QuantizationComponentFactory.reconstruct_partial_qparams_calculator(
-        qspec.observer_or_fake_quant_ctr, qscheme=qscheme, float_range=float_range
-    )
-
-    # qscheme in TorchAOQuantizationSpec is not read by coreai-opt later on so we omit it.
-    # Only the qscheme contained within observer_or_fake_quant_ctr matters.
-    node.meta[Q_ANNOTATION_KEY].output_qspec = TorchAOQuantizationSpec(
-        observer_or_fake_quant_ctr=ctr,
-        dtype=qspec.dtype,
-        quant_min=qspec.quant_min,
-        quant_max=qspec.quant_max,
-    )
-    _propagate_adjusted_spec_to_child_nodes(node, qscheme, float_range, shared_observer_nodes)
 
 
 def _get_weighted_mod_pattern(
@@ -634,20 +474,6 @@ def get_embedding_pattern() -> torch.nn.Module:
     return _get_aten_graph_module_for_pattern(WrapperModule(_embedding), example_inputs)
 
 
-def find_consumers(
-    pattern_nodes: Iterable[torch.fx.Node], target_nodes: list[torch.fx.Node]
-) -> set[torch.fx.Node]:
-    """Find all nodes that take as input any of the target nodes"""
-    consumers = []
-    for node in pattern_nodes:
-        if node is None:
-            continue
-        for arg in node.all_input_nodes:
-            if arg in target_nodes:
-                consumers.append(node)
-    return set(consumers)
-
-
 def _is_fx_node_floating_point(node: torch.fx.Node) -> bool:
     """
     Check if a fx node has floating point data.
@@ -842,108 +668,6 @@ def _fill_input_qspec_map_for_input(
         input_qspec_map[input_node] = input_node.meta[Q_ANNOTATION_KEY].output_qspec
 
 
-def _get_output_qspec(
-    node: torch.fx.Node,
-    quantization_config: AnnotationConfig,
-    shared_observer_nodes: set[torch.fx.Node] | None = None,
-) -> TorchAOQuantizationSpec | None:
-    """
-    Get the output qspec which should be associated with the node. Check child nodes
-    first to see if any input qspec is already set, and if so, reuse the qspec.
-    If there are multiple child nodes, the qspec will be the first valid one found when
-    checking all child nodes.
-    When encountering shared observer nodes as child nodes, continue checking their
-    children if no valid input qspec is found.
-    """
-    op_output_spec = quantization_config.op_output_spec
-
-    # Early exit if input node is not floating point dtype
-    if not _is_fx_node_floating_point(node):
-        # Hardcoding for index 0 for now while we only support single output setting
-        if 0 in op_output_spec:
-            _warn_non_quantizable_tensor_setting(node, "output", 0, op_output_spec)
-        return None
-
-    # First read qspec from config without applying it yet.
-    qspec_from_config, _ = get_last_matching_spec([0], op_output_spec)
-
-    # Don't set output qspec if it is specified to be None. If the op has multiple child
-    # ops where a subset of child ops don't have input quantization, we should not
-    # insert a quantizer for the op's output.
-    if qspec_from_config is None:
-        return None
-
-    # Check child ops to see if qspec settings should be taken from them.
-    # Current logic simply uses the first child qspec found as the qspec to use.
-    # This logic might need to be updated to be smarter in how the qspec to use is
-    # determined.
-    if not shared_observer_nodes:
-        shared_observer_nodes = set()
-    nodes_to_check = [user for user in node.users]
-    while nodes_to_check:
-        curr_node = nodes_to_check.pop(0)
-        if (
-            is_node_annotated(curr_node)
-            and curr_node.meta[Q_ANNOTATION_KEY].input_qspec_map.get(node) is not None
-        ):
-            return curr_node.meta[Q_ANNOTATION_KEY].input_qspec_map.get(node)
-        # Check children of shared observer nodes as well in a DFS fashion
-        if curr_node in shared_observer_nodes:
-            nodes_to_check[:0] = curr_node.users
-
-    # If no valid qspec was found, refer to quantization config
-    return qspec_from_config
-
-
-def _propagate_output_qspec(
-    node: torch.fx.Node,
-    output_qspec: TorchAOQuantizationSpec,
-    shared_observer_nodes: set[torch.fx.Node] | None = None,
-):
-    """
-    Propagate output qspec to child ops which are shared observer nodes. These node
-    types should simply echo the qspec which is coming from its input.
-    Propagated specs will be SharedQuantizationSpecs except for the first input qspec
-    that is set, since all subsequent SharedQuantizationSpecs will be referring to the
-    first input qspec set.
-    This function should be called for each annotation function which is defined.
-    """
-    if output_qspec is None or not shared_observer_nodes or not node.users:
-        return
-    if not shared_observer_nodes:
-        shared_observer_nodes = set()
-    spec_to_propagate = output_qspec
-    nodes_to_propagate = [user for user in node.users if user in shared_observer_nodes]
-
-    while nodes_to_propagate:
-        user = nodes_to_propagate.pop(0)
-        # Skip propagation for a node which is already annotated
-        if is_any_annotated([user]):
-            continue
-        input_qspec_map = {}
-        if isinstance(spec_to_propagate, _SharedQuantizationSpec):
-            # If spec to propagate is already a shared qspec, we can simply update all
-            # shared observer inputs and outputs with the shared qspec
-            for input_node in user.all_input_nodes:
-                input_qspec_map[input_node] = spec_to_propagate
-        else:
-            # If spec is not a shared qspec, this is the very first qspec we are
-            # setting. Set the first input to be this qspec, then update
-            # spec_to_propagate to be a shared qspec to be used for all other updates
-            first_user_input = user.all_input_nodes[0]
-            input_qspec_map[first_user_input] = spec_to_propagate
-            spec_to_propagate = _SharedQuantizationSpec((first_user_input, user))
-            for input_node in user.all_input_nodes[1:]:
-                input_qspec_map[input_node] = spec_to_propagate
-
-        user.meta[Q_ANNOTATION_KEY] = QuantizationAnnotation(
-            input_qspec_map=input_qspec_map, output_qspec=spec_to_propagate
-        )
-        mark_nodes_as_annotated([user])
-
-        nodes_to_propagate.extend([child for child in user.users if child in shared_observer_nodes])
-
-
 def _get_call_function_node_from_partition(partition: SourcePartition) -> torch.fx.Node:
     """
     Given a partition, return the call function node associated with the partition.
@@ -1041,179 +765,6 @@ def match_pattern_with_subgraph_matcher(
         # Use the node marked with "mod" as the key
         node_to_match_dict[mod_node] = subgraph_match
     return node_to_match_dict
-
-
-def annotate_weighted_mod_match(
-    annotator_match: InternalMatch,
-    quantization_config: AnnotationConfig,
-    context: AnnotationContext,
-) -> None:
-    """
-    Try to annotate specific nodes in the model designated by ``annotator_match`` using
-    ``quantization_config``.
-    """
-    # Entries in name_node_map will be determined by what is populated in
-    # node_dict when the pattern was created.
-    name_node_map = annotator_match.name_node_map
-    mod_node = name_node_map["mod"]
-    bn_node = name_node_map.get("bn")
-    output_node = None
-    if "output" in name_node_map:
-        # In this case, an activation is applied to the weighted module output
-        output_node = name_node_map["output"]
-        # If the output is same as bn_node or mod_node, it means we have an inplace
-        # activation, so we need to correct the node.
-        if bn_node is not None and bn_node == output_node:
-            bn_node = bn_node.args[0]
-        elif mod_node == output_node:
-            mod_node = mod_node.args[0]
-
-    # TODO: skip partition if any intermediate node output is used by an op outside the pattern.
-
-    # Skip partition if already annotated
-    partition = [mod_node]
-    partition.extend(filter(None, [bn_node, output_node]))
-
-    if is_any_annotated(partition):
-        return
-
-    shared_observer_nodes = context.shared_observer_nodes
-    input_qspec_map = _get_input_qspec_map(
-        mod_node.all_input_nodes,
-        quantization_config,
-        context,
-    )
-    output_qspec = _get_output_qspec(
-        output_node or mod_node, quantization_config, shared_observer_nodes
-    )
-    # set mod_node
-    mod_node.meta[Q_ANNOTATION_KEY] = QuantizationAnnotation(
-        input_qspec_map=input_qspec_map,
-        output_qspec=None if output_node else output_qspec,
-    )
-    # set output_node if exists
-    if output_node:
-        output_node.meta[Q_ANNOTATION_KEY] = QuantizationAnnotation(output_qspec=output_qspec)
-
-    # apply output spec to either final output_node or mod_node
-    _propagate_output_qspec(output_node or mod_node, output_qspec, shared_observer_nodes)
-
-    # Mark all nodes in pattern as annotated
-    mark_nodes_as_annotated(partition)
-
-
-def annotate_n_ary_act_match(
-    annotator_match: tuple[SourcePartition],
-    quantization_config: AnnotationConfig,
-    context: AnnotationContext,
-) -> None:
-    """
-    Try to annotate specific nodes in the model designated by ``annotator_match`` using
-    ``quantization_config``.
-    """
-    if len(annotator_match) > 2:
-        error_msg = (
-            "Sequential list of ops is longer than 2. Only lists of up to "
-            "length 2 (op + [act]_ are supported."
-        )
-        raise RuntimeError(error_msg)
-    nodes_to_annotate = [
-        _get_call_function_node_from_partition(partition) for partition in annotator_match
-    ]
-    first_op_node = nodes_to_annotate[0]
-    last_op_node = nodes_to_annotate[-1]
-
-    if is_any_annotated(nodes_to_annotate):
-        return
-
-    # TODO: skip partition if any intermediate node output is used by an op outside the pattern.
-
-    shared_observer_nodes = context.shared_observer_nodes
-    input_qspec_map = _get_input_qspec_map(
-        first_op_node.all_input_nodes,
-        quantization_config,
-        context,
-    )
-    output_qspec = _get_output_qspec(last_op_node, quantization_config, shared_observer_nodes)
-    if len(nodes_to_annotate) == 1:
-        first_op_node.meta[Q_ANNOTATION_KEY] = QuantizationAnnotation(
-            input_qspec_map=input_qspec_map,
-            output_qspec=output_qspec,
-            _annotated=True,
-        )
-    else:
-        first_op_node.meta[Q_ANNOTATION_KEY] = QuantizationAnnotation(
-            input_qspec_map=input_qspec_map,
-            _annotated=True,
-        )
-        last_op_node.meta[Q_ANNOTATION_KEY] = QuantizationAnnotation(
-            output_qspec=output_qspec,
-            _annotated=True,
-        )
-    _propagate_output_qspec(last_op_node, output_qspec, shared_observer_nodes)
-
-
-def _adjust_input_qspec_map_for_shared_observers(
-    op_node: Node, input_qspec_map: dict[Node, TorchAOQuantizationSpec]
-) -> _SharedQuantizationSpec | None:
-    """
-    For shared observer ops, check if any inputs have qspecs. If so,
-    1. set the first input to the first valid qspec
-    2. set all subsequent inputs to use SharedObserverQspec tied to the first input
-
-    This logic is mainly needed for multi-input shared observer ops (concat).
-    A SharedObserverQspec is returned for use as output_qspec.
-    """
-    shared_qspec = None
-    for input_node in op_node.all_input_nodes:
-        if input_qspec_map[input_node] is not None:
-            input_qspec_map[op_node.all_input_nodes[0]] = input_qspec_map[input_node]
-    if input_qspec_map[op_node.all_input_nodes[0]] is not None:
-        shared_qspec = _SharedQuantizationSpec((op_node.all_input_nodes[0], op_node))
-        for input_node in op_node.all_input_nodes[1:]:
-            input_qspec_map[input_node] = shared_qspec
-    return shared_qspec
-
-
-def annotate_shared_observer_match(
-    annotator_match: tuple[SourcePartition],
-    quantization_config: AnnotationConfig,
-    context: AnnotationContext,
-) -> None:
-    """
-    Try to annotate specific nodes in the model designated by ``annotator_match`` using
-    ``quantization_config``.
-    """
-    if len(annotator_match) > 1:
-        error_msg = (
-            "Shared observer pattern is expected to be length 1, but got "
-            f"{len(annotator_match)}. Annotator match: {annotator_match}."
-        )
-        raise RuntimeError(error_msg)
-
-    op_node = _get_call_function_node_from_partition(annotator_match[0])
-    if is_node_annotated(op_node):
-        return
-
-    shared_observer_nodes = context.shared_observer_nodes
-    input_qspec_map = _get_input_qspec_map(
-        op_node.all_input_nodes,
-        quantization_config,
-        context,
-    )
-    output_qspec = _adjust_input_qspec_map_for_shared_observers(op_node, input_qspec_map)
-
-    if output_qspec is None:
-        # Only use a different output qspec if it isn't sharing with its input
-        output_qspec = _get_output_qspec(op_node, quantization_config, shared_observer_nodes)
-
-    # input and output of op will share quantization parameter with input of op
-    op_node.meta[Q_ANNOTATION_KEY] = QuantizationAnnotation(
-        input_qspec_map=input_qspec_map,
-        output_qspec=output_qspec,
-        _annotated=True,
-    )
-    _propagate_output_qspec(op_node, output_qspec, shared_observer_nodes)
 
 
 def annotate_module_level_specs(

--- a/src/coreai_opt/quantization/_graph/_provisional_qspec_generation.py
+++ b/src/coreai_opt/quantization/_graph/_provisional_qspec_generation.py
@@ -1,0 +1,398 @@
+# Copyright 2026 Apple Inc.
+#
+# Use of this source code is governed by a BSD-3-Clause license that can
+# be found in the LICENSE file or at https://opensource.org/licenses/BSD-3-Clause
+
+"""Seed a :class:`ProvisionalQSpecMap` from the winning configs.
+
+Each covered node seeds its OUTPUT slot, plus every INPUT slot whose producer
+lies outside its pattern group. Ops with a known output distribution (sigmoid,
+tanh, hardsigmoid, relu, relu6, hardtanh) also propose ``QSCHEME`` and
+``FLOAT_RANGE`` at :data:`OP_INTRINSIC_PRIORITY`.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Mapping
+from typing import Any
+
+import torch.fx as fx
+
+from coreai_opt._utils.config_utils import ALL_TENSORS, get_last_matching_spec
+from coreai_opt._utils.fx_utils import (
+    get_local_state_name,
+    is_coreai_compressed_state_node as _is_state_node,
+)
+from coreai_opt.config.spec import CompressionTargetTensor
+from coreai_opt.quantization.config import OpQuantizerConfig
+from coreai_opt.quantization.spec import (
+    QuantizationScheme,
+    QuantizationSpec,
+)
+
+from ._annotation_utils import (
+    _fixed_q_params_ops,
+    _get_state_aliases,
+    _hardtanh_ops,
+    _is_fx_node_floating_point,
+    _warn_non_quantizable_tensor_setting,
+)
+from ._qspec_constraints import _get_or_create
+from ._qspec_types import (
+    OP_INTRINSIC_PRIORITY,
+    FieldName,
+    FieldValue,
+    NodeSlot,
+    ProvisionalQSpecMap,
+    ReconciliationError,
+    SlotKind,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# Exactly the settable inputs of QuantizationSpec, which _qspec_resolution
+# reassembles one from. Adding an attribute is a line here and a line there.
+_FIELD_FROM_SPEC_ATTR: dict[FieldName, str] = {
+    FieldName.DTYPE: "dtype",
+    FieldName.QSCHEME: "qscheme",
+    FieldName.QFORMULATION: "qformulation",
+    FieldName.GRANULARITY: "granularity",
+    FieldName.FLOAT_RANGE: "float_range",
+    FieldName.FAKE_QUANTIZE_CLS: "fake_quantize_cls",
+    FieldName.QPARAM_CALCULATOR_CLS: "qparam_calculator_cls",
+    FieldName.RANGE_CALCULATOR_CLS: "range_calculator_cls",
+    FieldName.SCALE_DTYPE: "scale_dtype",
+}
+
+
+_NO_MATCH = object()
+"""Sentinel: no key in the spec map addressed this slot.
+
+Distinct from a key that matched and held ``None``, which is a decline.
+"""
+
+
+# ---------------------------------------------------------------------------
+# Entry point.
+# ---------------------------------------------------------------------------
+
+
+def build_initial_provisional_qspecs(
+    winning_configs: dict[fx.Node, OpQuantizerConfig],
+    node_priorities: dict[fx.Node, int],
+    pattern_groups: dict[fx.Node, frozenset[fx.Node]],
+    module_name_to_state_names_map: Mapping[str, Mapping[str, list[str]]],
+    primary_nodes: set[fx.Node],
+) -> ProvisionalQSpecMap:
+    """Build the initial map from the winning configs and op intrinsics."""
+    qspecs: ProvisionalQSpecMap = {}
+    for node, cfg in winning_configs.items():
+        priority = node_priorities[node]
+        pattern = pattern_groups.get(node, frozenset({node}))
+        if node in primary_nodes:
+            # A pattern's input and state specs belong to the op it is anchored
+            # on. Seeding them on the other covered nodes would quantize their
+            # parameters too — a conv-bn would fake-quantize the bn's affine
+            # scale alongside the folded conv weight.
+            _populate_input_slots(
+                node, cfg, priority, pattern, qspecs, module_name_to_state_names_map
+            )
+        _populate_output_slot(node, cfg, priority, pattern, qspecs)
+
+    return qspecs
+
+
+# ---------------------------------------------------------------------------
+# Input-slot population.
+# ---------------------------------------------------------------------------
+
+
+def _populate_input_slots(
+    node: fx.Node,
+    cfg: OpQuantizerConfig,
+    priority: int,
+    pattern: frozenset[fx.Node],
+    qspecs: ProvisionalQSpecMap,
+    module_name_to_state_names_map: Mapping[str, Mapping[str, list[str]]],
+) -> None:
+    """Populate every non-internal INPUT slot on ``node`` from its config."""
+    for arg_index, producer in enumerate(node.all_input_nodes):
+        if producer in pattern:
+            continue  # internal edge — skip
+        if not _is_fx_node_floating_point(producer):
+            # Unobservable, not declined: a fact about the graph rather than a
+            # user decision, so it must not suppress a group it joins.
+            _warn_if_non_quantizable_input_configured(producer, arg_index, cfg)
+            continue
+        slot = NodeSlot(node=node, kind=SlotKind.INPUT, arg_index=arg_index)
+        if _is_state_node(producer):
+            _validate_state_not_referenced_via_input_spec(producer, arg_index, cfg)
+            spec = _lookup_state_spec(
+                cfg, producer, module_name_to_state_names_map
+            )
+            target = CompressionTargetTensor.WEIGHT
+        else:
+            spec = _lookup_by_key(cfg.op_input_spec, arg_index)
+            target = CompressionTargetTensor.ACTIVATION
+        if spec is None:
+            # A key named this slot and held None: an explicit opt-out.
+            _mark_declined(qspecs, slot, priority)
+            continue
+        if spec is _NO_MATCH:
+            # No key addressed this slot, so the config has no opinion on it.
+            continue
+        _populate_fields_from_spec(qspecs, slot, spec, priority, target)
+
+
+def _warn_if_non_quantizable_input_configured(
+    producer: fx.Node, arg_index: int, cfg: OpQuantizerConfig
+) -> None:
+    """Warn when the user named a non-floating-point input explicitly.
+
+    A ``*`` spec sweeping up an int tensor is routine and stays silent.
+    """
+    if arg_index in cfg.op_input_spec:
+        _warn_non_quantizable_tensor_setting(
+            producer, "input", arg_index, cfg.op_input_spec
+        )
+    if _is_state_node(producer):
+        state_name = get_local_state_name(producer)
+        if state_name is not None and state_name in cfg.op_state_spec:
+            _warn_non_quantizable_tensor_setting(
+                producer, "state", state_name, cfg.op_state_spec
+            )
+
+
+def _validate_state_not_referenced_via_input_spec(
+    state_producer: fx.Node, arg_index: int, cfg: OpQuantizerConfig
+) -> None:
+    """Raise if the user's ``op_input_spec`` targets an arg index whose
+    producer is a state tensor. State tensors must be configured via
+    ``op_state_spec``.
+    """
+    if arg_index in cfg.op_input_spec:
+        raise RuntimeError(
+            f"Config is attempting to set op_input_spec idx {arg_index}, "
+            f"but the input is a state tensor (node: {state_producer.name}). "
+            f"Use op_state_spec to configure state inputs instead.\n"
+            f"op_input_spec: {cfg.op_input_spec}"
+        )
+
+
+def _lookup_state_spec(
+    consumer_cfg: OpQuantizerConfig,
+    state_node: fx.Node,
+    module_name_to_state_names_map: Mapping[str, Mapping[str, list[str]]],
+) -> QuantizationSpec | None:
+    """Resolve a state consumer's spec from its ``op_state_spec``.
+
+    A shared parameter has several local names — ``linear1.my_weight`` and
+    ``linear2.other_weight`` may be one tensor — and each consumer's config keys
+    on the one it knows, so match against the whole alias set.
+    """
+    if get_local_state_name(state_node) is None:
+        # Already-compressed state (e.g. a palettization lut_to_dense output)
+        # has no state name and isn't quantized.
+        return None
+    state_names = _get_state_aliases(state_node, module_name_to_state_names_map)
+    spec, matched = get_last_matching_spec(state_names, consumer_cfg.op_state_spec)
+    if spec is None and not matched:
+        # Nothing in op_state_spec addressed this tensor — no opinion.
+        return _NO_MATCH
+    return spec
+
+
+# ---------------------------------------------------------------------------
+# Output-slot population + op-intrinsic override.
+# ---------------------------------------------------------------------------
+
+
+def _populate_output_slot(
+    node: fx.Node,
+    cfg: OpQuantizerConfig,
+    priority: int,
+    pattern: frozenset[fx.Node],
+    qspecs: ProvisionalQSpecMap,
+) -> None:
+    """Populate ``node``'s OUTPUT slot from its config, then apply any
+    op-intrinsic override.
+
+    Raises on two pattern shapes the rules can't handle: an op-intrinsic node
+    fully internal to a pattern, whose contribution would have nowhere to land,
+    and a covered node with consumers both inside and outside its pattern.
+    """
+    if not node.users:
+        return
+
+    if not _is_fx_node_floating_point(node):
+        # Not a tensor — e.g. the SymInt shape-assertion `mul`s torch.export
+        # synthesizes. A qspec here would send an int to the qparams calculator.
+        if 0 in cfg.op_output_spec:
+            _warn_non_quantizable_tensor_setting(node, "output", 0, cfg.op_output_spec)
+        return
+
+    consumers_in_pattern = [
+        consumer for consumer in node.users if consumer in pattern
+    ]
+    consumers_outside_pattern = [
+        consumer for consumer in node.users if consumer not in pattern
+    ]
+
+    has_intrinsic = _get_op_intrinsic(node) is not None
+
+    if consumers_in_pattern and consumers_outside_pattern:
+        in_pattern_names = sorted(consumer.name for consumer in consumers_in_pattern)
+        external_names = sorted(consumer.name for consumer in consumers_outside_pattern)
+        raise ReconciliationError(
+            f"Node {node.name!r} (target={node.target!r}) has consumers both "
+            f"inside and outside its pattern group, so an observer added for the "
+            f"external ones would also be visible to the internal ones.\n"
+            f"  pattern group: {sorted(covered.name for covered in pattern)}\n"
+            f"  in-pattern consumers: {in_pattern_names}\n"
+            f"  external consumers: {external_names}"
+        )
+
+    fully_internal = not consumers_outside_pattern
+    if fully_internal:
+        if has_intrinsic:
+            raise ReconciliationError(
+                f"Op-intrinsic node {node.name!r} (target={node.target!r}) "
+                f"has all consumers inside its pattern group "
+                f"{sorted(covered.name for covered in pattern)}"
+            )
+        return
+
+    output_slot = NodeSlot(node=node, kind=SlotKind.OUTPUT, arg_index=0)
+    out_spec = _lookup_by_key(cfg.op_output_spec, 0)
+    if out_spec is None:
+        _mark_declined(qspecs, output_slot, priority)
+        return
+    if out_spec is _NO_MATCH:
+        return
+
+    _populate_fields_from_spec(
+        qspecs, output_slot, out_spec, priority, CompressionTargetTensor.ACTIVATION
+    )
+    if has_intrinsic:
+        _apply_op_intrinsic_override(node, output_slot, out_spec, qspecs)
+
+
+def _apply_op_intrinsic_override(
+    node: fx.Node,
+    output_slot: NodeSlot,
+    user_spec: QuantizationSpec,
+    qspecs: ProvisionalQSpecMap,
+) -> None:
+    """Propose ``QSCHEME`` and ``FLOAT_RANGE`` from the op's known output
+    distribution, at :data:`OP_INTRINSIC_PRIORITY` so they outrank user config.
+
+    Nothing else: the op has no opinion on the other fields.
+    """
+    intrinsic = _get_op_intrinsic(node)
+    assert intrinsic is not None, "caller must gate on _get_op_intrinsic"
+    scheme, float_range = intrinsic
+
+    _override_field(
+        qspecs, output_slot, FieldName.QSCHEME,
+        scheme, OP_INTRINSIC_PRIORITY, node, user_spec.qscheme, "qscheme",
+    )
+    _override_field(
+        qspecs, output_slot, FieldName.FLOAT_RANGE,
+        list(float_range), OP_INTRINSIC_PRIORITY, node,
+        user_spec.float_range, "float_range",
+    )
+
+
+def _override_field(
+    qspecs: ProvisionalQSpecMap,
+    slot: NodeSlot,
+    field_name: FieldName,
+    intrinsic_value: Any,
+    priority: int,
+    node: fx.Node,
+    user_value: Any,
+    human_field_name: str,
+) -> None:
+    """Write ``intrinsic_value`` at ``field_name`` on ``slot``, logging only if
+    ``user_value`` asked for something different.
+    """
+    qspec = _get_or_create(qspecs, slot)
+    qspec.fields[field_name] = FieldValue(value=intrinsic_value, priority=priority)
+    if user_value is not None and user_value != intrinsic_value:
+        logger.info(
+            "Op-intrinsic override on %s (target=%s): user %s=%r overridden "
+            "by intrinsic %s=%r.",
+            node.name, node.target, human_field_name, user_value,
+            human_field_name, intrinsic_value,
+        )
+
+
+def _get_op_intrinsic(
+    node: fx.Node,
+) -> tuple[QuantizationScheme, tuple[float | None, float | None]] | None:
+    """Return ``(qscheme, float_range)`` for ops with a known output distribution.
+
+    Fixed-bound ops come from :data:`_fixed_q_params_ops`; ``hardtanh`` takes its
+    bounds from the node's args and is symmetric iff ``min == -max``.
+    """
+    if node.target in _fixed_q_params_ops:
+        return _fixed_q_params_ops[node.target]
+    if node.target in _hardtanh_ops and len(node.args) >= 3:
+        min_val, max_val = node.args[1], node.args[2]
+        scheme = (
+            QuantizationScheme.SYMMETRIC
+            if min_val == -max_val
+            else QuantizationScheme.ASYMMETRIC
+        )
+        return scheme, (float(min_val), float(max_val))
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Spec-population helpers.
+# ---------------------------------------------------------------------------
+
+
+def _mark_declined(
+    qspecs: ProvisionalQSpecMap, slot: NodeSlot, priority: int
+) -> None:
+    """Record that ``slot``'s config declined to observe it, keeping the strongest
+    declining priority.
+    """
+    qspec = _get_or_create(qspecs, slot)
+    if qspec.declined_by is None or priority < qspec.declined_by:
+        qspec.declined_by = priority
+
+
+def _populate_fields_from_spec(
+    qspecs: ProvisionalQSpecMap,
+    slot: NodeSlot,
+    spec: QuantizationSpec,
+    priority: int,
+    target: CompressionTargetTensor,
+) -> None:
+    """Seed ``slot``'s fields from a coreai_opt :class:`QuantizationSpec`.
+
+    Reads the spec's settable inputs rather than a converted torchao spec, so
+    each property the user configured stays independently reconcilable.
+    """
+    qspec = _get_or_create(qspecs, slot)
+    for field_name, attr in _FIELD_FROM_SPEC_ATTR.items():
+        qspec.fields[field_name] = FieldValue(
+            value=getattr(spec, attr), priority=priority
+        )
+    qspec.fields[FieldName.QUANTIZATION_TARGET] = FieldValue(
+        value=target, priority=priority
+    )
+
+
+def _lookup_by_key(spec_map: dict[Any, Any], key: Any) -> Any:
+    """Look up ``key`` in an ``op_input/op_output/op_state`` map with ``*``
+    fallback, returning :data:`_NO_MATCH` when nothing addressed ``key``."""
+    if key in spec_map:
+        return spec_map[key]
+    if ALL_TENSORS in spec_map:
+        return spec_map[ALL_TENSORS]
+    return _NO_MATCH

--- a/src/coreai_opt/quantization/_graph/_provisional_qspec_generation.py
+++ b/src/coreai_opt/quantization/_graph/_provisional_qspec_generation.py
@@ -279,21 +279,30 @@ def _apply_op_intrinsic_override(
     distribution, at :data:`OP_INTRINSIC_PRIORITY` so they outrank user config.
 
     Nothing else: the op has no opinion on the other fields.
+
+    The ``QSCHEME`` half is skipped for a floating-point dtype, which admits only
+    the symmetric scheme — see ``QuantizationSpec.validate_qscheme_for_fp_quant``.
+    An op like ``relu`` proposes an asymmetric scheme to exploit its one-sided
+    range, but that is a representational choice the dtype forbids, so proposing it
+    would make the group unbuildable rather than merely lower quality. The
+    ``FLOAT_RANGE`` half still applies: the bound is a fact about the data and
+    holds whatever the dtype.
     """
     intrinsic = _get_op_intrinsic(node)
     assert intrinsic is not None, "caller must gate on _get_op_intrinsic"
     scheme, float_range = intrinsic
 
-    _override_field(
-        qspecs,
-        output_slot,
-        FieldName.QSCHEME,
-        scheme,
-        OP_INTRINSIC_PRIORITY,
-        node,
-        user_spec.qscheme,
-        "qscheme",
-    )
+    if not user_spec.dtype.is_floating_point:
+        _override_field(
+            qspecs,
+            output_slot,
+            FieldName.QSCHEME,
+            scheme,
+            OP_INTRINSIC_PRIORITY,
+            node,
+            user_spec.qscheme,
+            "qscheme",
+        )
     _override_field(
         qspecs,
         output_slot,

--- a/src/coreai_opt/quantization/_graph/_provisional_qspec_generation.py
+++ b/src/coreai_opt/quantization/_graph/_provisional_qspec_generation.py
@@ -129,9 +129,7 @@ def _populate_input_slots(
         slot = NodeSlot(node=node, kind=SlotKind.INPUT, arg_index=arg_index)
         if _is_state_node(producer):
             _validate_state_not_referenced_via_input_spec(producer, arg_index, cfg)
-            spec = _lookup_state_spec(
-                cfg, producer, module_name_to_state_names_map
-            )
+            spec = _lookup_state_spec(cfg, producer, module_name_to_state_names_map)
             target = CompressionTargetTensor.WEIGHT
         else:
             spec = _lookup_by_key(cfg.op_input_spec, arg_index)
@@ -154,15 +152,11 @@ def _warn_if_non_quantizable_input_configured(
     A ``*`` spec sweeping up an int tensor is routine and stays silent.
     """
     if arg_index in cfg.op_input_spec:
-        _warn_non_quantizable_tensor_setting(
-            producer, "input", arg_index, cfg.op_input_spec
-        )
+        _warn_non_quantizable_tensor_setting(producer, "input", arg_index, cfg.op_input_spec)
     if _is_state_node(producer):
         state_name = get_local_state_name(producer)
         if state_name is not None and state_name in cfg.op_state_spec:
-            _warn_non_quantizable_tensor_setting(
-                producer, "state", state_name, cfg.op_state_spec
-            )
+            _warn_non_quantizable_tensor_setting(producer, "state", state_name, cfg.op_state_spec)
 
 
 def _validate_state_not_referenced_via_input_spec(
@@ -233,12 +227,8 @@ def _populate_output_slot(
             _warn_non_quantizable_tensor_setting(node, "output", 0, cfg.op_output_spec)
         return
 
-    consumers_in_pattern = [
-        consumer for consumer in node.users if consumer in pattern
-    ]
-    consumers_outside_pattern = [
-        consumer for consumer in node.users if consumer not in pattern
-    ]
+    consumers_in_pattern = [consumer for consumer in node.users if consumer in pattern]
+    consumers_outside_pattern = [consumer for consumer in node.users if consumer not in pattern]
 
     has_intrinsic = _get_op_intrinsic(node) is not None
 
@@ -295,13 +285,24 @@ def _apply_op_intrinsic_override(
     scheme, float_range = intrinsic
 
     _override_field(
-        qspecs, output_slot, FieldName.QSCHEME,
-        scheme, OP_INTRINSIC_PRIORITY, node, user_spec.qscheme, "qscheme",
+        qspecs,
+        output_slot,
+        FieldName.QSCHEME,
+        scheme,
+        OP_INTRINSIC_PRIORITY,
+        node,
+        user_spec.qscheme,
+        "qscheme",
     )
     _override_field(
-        qspecs, output_slot, FieldName.FLOAT_RANGE,
-        list(float_range), OP_INTRINSIC_PRIORITY, node,
-        user_spec.float_range, "float_range",
+        qspecs,
+        output_slot,
+        FieldName.FLOAT_RANGE,
+        list(float_range),
+        OP_INTRINSIC_PRIORITY,
+        node,
+        user_spec.float_range,
+        "float_range",
     )
 
 
@@ -322,10 +323,13 @@ def _override_field(
     qspec.fields[field_name] = FieldValue(value=intrinsic_value, priority=priority)
     if user_value is not None and user_value != intrinsic_value:
         logger.info(
-            "Op-intrinsic override on %s (target=%s): user %s=%r overridden "
-            "by intrinsic %s=%r.",
-            node.name, node.target, human_field_name, user_value,
-            human_field_name, intrinsic_value,
+            "Op-intrinsic override on %s (target=%s): user %s=%r overridden by intrinsic %s=%r.",
+            node.name,
+            node.target,
+            human_field_name,
+            user_value,
+            human_field_name,
+            intrinsic_value,
         )
 
 
@@ -342,9 +346,7 @@ def _get_op_intrinsic(
     if node.target in _hardtanh_ops and len(node.args) >= 3:
         min_val, max_val = node.args[1], node.args[2]
         scheme = (
-            QuantizationScheme.SYMMETRIC
-            if min_val == -max_val
-            else QuantizationScheme.ASYMMETRIC
+            QuantizationScheme.SYMMETRIC if min_val == -max_val else QuantizationScheme.ASYMMETRIC
         )
         return scheme, (float(min_val), float(max_val))
     return None
@@ -355,9 +357,7 @@ def _get_op_intrinsic(
 # ---------------------------------------------------------------------------
 
 
-def _mark_declined(
-    qspecs: ProvisionalQSpecMap, slot: NodeSlot, priority: int
-) -> None:
+def _mark_declined(qspecs: ProvisionalQSpecMap, slot: NodeSlot, priority: int) -> None:
     """Record that ``slot``'s config declined to observe it, keeping the strongest
     declining priority.
     """
@@ -380,12 +380,8 @@ def _populate_fields_from_spec(
     """
     qspec = _get_or_create(qspecs, slot)
     for field_name, attr in _FIELD_FROM_SPEC_ATTR.items():
-        qspec.fields[field_name] = FieldValue(
-            value=getattr(spec, attr), priority=priority
-        )
-    qspec.fields[FieldName.QUANTIZATION_TARGET] = FieldValue(
-        value=target, priority=priority
-    )
+        qspec.fields[field_name] = FieldValue(value=getattr(spec, attr), priority=priority)
+    qspec.fields[FieldName.QUANTIZATION_TARGET] = FieldValue(value=target, priority=priority)
 
 
 def _lookup_by_key(spec_map: dict[Any, Any], key: Any) -> Any:

--- a/src/coreai_opt/quantization/_graph/_qspec_constraint_generation.py
+++ b/src/coreai_opt/quantization/_graph/_qspec_constraint_generation.py
@@ -1,0 +1,421 @@
+# Copyright 2026 Apple Inc.
+#
+# Use of this source code is governed by a BSD-3-Clause license that can
+# be found in the LICENSE file or at https://opensource.org/licenses/BSD-3-Clause
+
+"""Constraint generation for the qspec reconciliation drain loop.
+
+:func:`_generate_constraints_for_node` runs once per fx node to seed the queue,
+then again whenever a node's slots change, so a newly-populated slot can trigger
+constraints that did not apply while it was empty. The sources are adjacent
+edges, shared-observer patterns, shared-state consumers, and shape-only ops.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any
+
+import torch
+import torch.fx as fx
+from torch.fx.passes.utils.matcher_utils import InternalMatch
+from torch.fx.passes.utils.source_matcher_utils import SourcePartition
+
+from coreai_opt._utils.fx_utils import is_coreai_compressed_state_node as _is_state_node
+from coreai_opt.quantization.config import OpQuantizerConfig
+
+from ._annotation_pattern_registry import (
+    _OPERAND_NODE_OPS,
+    SharedObserverModulePattern,
+)
+from ._annotation_utils import _get_call_function_node_from_partition
+from ._qspec_constraints import Constraint, InheritFields, ShareObserverInstance
+from ._qspec_types import FieldName, NodeSlot, ProvisionalQSpecMap, SlotKind
+
+# Shape-only ops: their output is numerically their input. Split on whether
+# they preserve tensor rank, which decides how much can be shared across them.
+#
+# Rank-preserving — safe to share one observer instance.
+_RANK_PRESERVING_PASSTHROUGH_OPS: frozenset = frozenset(
+    {
+        torch.ops.aten.clone,
+        torch.ops.aten.dropout,
+        torch.ops.aten.feature_dropout,
+        torch.ops.aten.permute,
+        torch.ops.aten.slice,
+        torch.ops.aten.t,
+        torch.ops.aten.transpose,
+    }
+)
+
+# Rank-changing — cannot share an instance, since a QParamsCalculator sizes its
+# buffers to the first tensor it sees (see QParamsCalculatorBase._resolve_axis).
+# ``expand`` belongs here: Tensor.expand can prepend leading dimensions.
+_RANK_CHANGING_PASSTHROUGH_OPS: frozenset = frozenset(
+    {
+        torch.ops.aten.expand,
+        torch.ops.aten.reshape,
+        torch.ops.aten.select,
+        torch.ops.aten.squeeze,
+        torch.ops.aten.unsqueeze,
+        torch.ops.aten.view,
+    }
+)
+
+# Every shape-only op, regardless of what can be shared across it.
+# tests/quantization/test_annotation_utils.py checks each member lowers to the
+# ATen packet named here.
+_PASSTHROUGH_OP_OVERLOADS: frozenset = (
+    _RANK_PRESERVING_PASSTHROUGH_OPS | _RANK_CHANGING_PASSTHROUGH_OPS
+)
+
+
+def _passthrough_kind(node: fx.Node) -> frozenset | None:
+    """Return which passthrough set ``node`` belongs to, or ``None``."""
+    if node.op != "call_function":
+        return None
+    packet = getattr(node.target, "overloadpacket", None)
+    if packet in _RANK_PRESERVING_PASSTHROUGH_OPS:
+        return _RANK_PRESERVING_PASSTHROUGH_OPS
+    if packet in _RANK_CHANGING_PASSTHROUGH_OPS:
+        return _RANK_CHANGING_PASSTHROUGH_OPS
+    return None
+
+
+def _is_passthrough(node: fx.Node) -> bool:
+    """Whether ``node`` is any shape-only op."""
+    return _passthrough_kind(node) is not None
+
+
+# ---------------------------------------------------------------------------
+# Context bundle.
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _AnnotationContext:
+    """Inputs to the reconciliation pipeline.
+
+    Attributes:
+        winning_configs (dict[fx.Node, OpQuantizerConfig]): Highest-priority
+            config per covered node.
+        node_priorities (dict[fx.Node, int]): Position in the annotation sort
+            order; lower means higher priority.
+        pattern_groups (dict[fx.Node, frozenset[fx.Node]]): The nodes in each
+            covered node's winning pattern match.
+        primary_nodes (set[fx.Node]): The node each pattern is anchored on — the
+            conv of a conv-bn-relu, not the bn or the relu. Only these consume
+            the config's input and state specs; the rest of a pattern is covered
+            for grouping and for carrying the output spec.
+        shared_observer_nodes (dict[fx.Node, type[SharedObserverModulePattern]]):
+            The pattern class owning each shared-observer node's semantics.
+        module_name_to_state_names_map (Mapping[str, Mapping[str, list[str]]]):
+            Per module, each reachable state FQN mapped to its local names. One
+            shared parameter has several, and each consumer's config may key on
+            a different one.
+    """
+
+    winning_configs: dict[fx.Node, OpQuantizerConfig]
+    node_priorities: dict[fx.Node, int]
+    pattern_groups: dict[fx.Node, frozenset[fx.Node]]
+    primary_nodes: set[fx.Node]
+    shared_observer_nodes: dict[fx.Node, type[SharedObserverModulePattern]]
+    module_name_to_state_names_map: Mapping[str, Mapping[str, list[str]]]
+
+
+# ---------------------------------------------------------------------------
+# Per-node constraint dispatch.
+# ---------------------------------------------------------------------------
+
+
+def _generate_constraints_for_node(
+    node: fx.Node, qspecs: ProvisionalQSpecMap, ctx: _AnnotationContext
+) -> list[Constraint]:
+    """Return every constraint whose scope includes ``node``.
+
+    Generators read the current ``qspecs``, so an already-decided neighboring
+    slot can make a rule emit a constraint it otherwise wouldn't.
+    """
+    constraints: list[Constraint] = []
+
+    constraints.extend(_adjacent_edge_constraints(node, qspecs, ctx))
+
+    pattern_class = ctx.shared_observer_nodes.get(node)
+    if pattern_class is not None:
+        constraints.extend(
+            pattern_class.generate_qspec_sharing_constraints(node, qspecs)
+        )
+
+    if _is_state_node(node) and len(node.users) >= 2:
+        constraints.extend(_shared_state_constraints(node, qspecs, ctx))
+
+    passthrough_kind = _passthrough_kind(node)
+    if passthrough_kind is _RANK_PRESERVING_PASSTHROUGH_OPS:
+        constraints.extend(_passthrough_op_constraints(node, qspecs, ctx))
+    elif passthrough_kind is _RANK_CHANGING_PASSTHROUGH_OPS:
+        constraints.extend(_rank_changing_passthrough_constraints(node, qspecs, ctx))
+
+    return constraints
+
+
+# ---------------------------------------------------------------------------
+# Adjacent-edge sharing.
+# ---------------------------------------------------------------------------
+
+
+def _adjacent_edge_constraints(
+    node: fx.Node, qspecs: ProvisionalQSpecMap, ctx: _AnnotationContext
+) -> list[Constraint]:
+    """Tie a tensor's producer OUTPUT slot to its consumer INPUT slot so one
+    observer serves both, per :func:`_edge_should_share`.
+
+    A decline suppresses the constraint rather than the whole group: the consumer
+    can observe its own input while the producer observes nothing, and either way
+    the edge carries one observer.
+
+    Constraints are pairwise, but :meth:`ShareObserverInstance.apply` widens each
+    group, so a node's whole fan-out ends up on one observer. Edges internal to a
+    pattern group are skipped.
+    """
+    if node not in ctx.winning_configs:
+        # A covered neighbor that cares about this edge emits it from its side.
+        return []
+
+    constraints: list[Constraint] = []
+    pattern = ctx.pattern_groups.get(node, frozenset({node}))
+
+    # Incoming edges.
+    for arg_index, producer in enumerate(node.all_input_nodes):
+        if producer in pattern:
+            continue
+        if producer not in ctx.winning_configs:
+            continue
+        producer_output = NodeSlot(node=producer, kind=SlotKind.OUTPUT, arg_index=0)
+        consumer_input = NodeSlot(node=node, kind=SlotKind.INPUT, arg_index=arg_index)
+        if _edge_should_share(producer_output, consumer_input, qspecs):
+            constraints.append(
+                ShareObserverInstance(frozenset({producer_output, consumer_input}))
+            )
+
+    # Outgoing edges.
+    for consumer in node.users:
+        if consumer in pattern:
+            continue
+        if consumer not in ctx.winning_configs:
+            continue
+        consumer_input = _find_input_slot_for_producer(consumer, node)
+        if consumer_input is None:
+            continue
+        producer_output = NodeSlot(node=node, kind=SlotKind.OUTPUT, arg_index=0)
+        if _edge_should_share(producer_output, consumer_input, qspecs):
+            constraints.append(
+                ShareObserverInstance(frozenset({producer_output, consumer_input}))
+            )
+
+    return constraints
+
+
+def _edge_should_share(
+    first: NodeSlot, second: NodeSlot, qspecs: ProvisionalQSpecMap
+) -> bool:
+    """Whether an edge's slots should share an observer: neither declined, and at
+    least one holding fields.
+
+    "At least one" is what populates an otherwise-empty INPUT slot, which a
+    downstream shared-observer pattern then needs in order to fire.
+    """
+    first_qspec, second_qspec = qspecs.get(first), qspecs.get(second)
+    if any(qspec is not None and qspec.declined for qspec in (first_qspec, second_qspec)):
+        return False
+    return any(
+        qspec is not None and bool(qspec.fields)
+        for qspec in (first_qspec, second_qspec)
+    )
+
+
+def _find_input_slot_for_producer(
+    consumer: fx.Node, producer: fx.Node
+) -> NodeSlot | None:
+    """Return the consumer's INPUT slot reading from ``producer``, if any."""
+    for arg_index, actual_producer in enumerate(consumer.all_input_nodes):
+        if actual_producer is producer:
+            return NodeSlot(node=consumer, kind=SlotKind.INPUT, arg_index=arg_index)
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Shared-state (shared-weight) sharing.
+# ---------------------------------------------------------------------------
+
+
+def _shared_state_constraints(
+    state_node: fx.Node, qspecs: ProvisionalQSpecMap, ctx: _AnnotationContext
+) -> list[Constraint]:
+    """Tie the INPUT slot of every covered consumer of ``state_node`` onto one
+    observer.
+
+    One copy of the tensor, quantized once, so every consumer must agree on the
+    spec — and one consumer declining it leaves it unquantized for all of them.
+    """
+    consumer_slots: list[NodeSlot] = []
+    for consumer in state_node.users:
+        if consumer not in ctx.winning_configs:
+            continue
+        consumer_input = _find_input_slot_for_producer(consumer, state_node)
+        if consumer_input is None:
+            continue
+        consumer_slots.append(consumer_input)
+
+    # Declined consumers participate; slots nothing spoke for stay out.
+    known_slots = [slot for slot in consumer_slots if slot in qspecs]
+    if len(known_slots) < 2:
+        return []
+    # Each consumer's config independently says whether it quantizes the tensor,
+    # so ordinary config precedence decides — including when it declines.
+    return [
+        ShareObserverInstance(frozenset(known_slots), priority_decides_decline=True)
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Passthrough-op propagation.
+# ---------------------------------------------------------------------------
+
+
+def _passthrough_op_constraints(
+    node: fx.Node, qspecs: ProvisionalQSpecMap, ctx: _AnnotationContext
+) -> list[Constraint]:
+    """Tie the slots around a rank-preserving shape-only op onto one observer.
+
+    Both sides see identical values at identical rank, so a second observer would
+    compute the same thing.
+    """
+    if not node.all_input_nodes:
+        return []
+
+    slots: set[NodeSlot] = {
+        NodeSlot(node=node, kind=SlotKind.INPUT, arg_index=0),
+        NodeSlot(node=node, kind=SlotKind.OUTPUT, arg_index=0),
+    }
+
+    producer = node.all_input_nodes[0]
+    if producer in ctx.winning_configs or _is_passthrough(producer):
+        slots.add(NodeSlot(node=producer, kind=SlotKind.OUTPUT, arg_index=0))
+
+    for consumer in node.users:
+        if consumer in ctx.winning_configs:
+            consumer_input = _find_input_slot_for_producer(consumer, node)
+            if consumer_input is not None:
+                slots.add(consumer_input)
+        elif _is_passthrough(consumer):
+            slots.add(NodeSlot(node=consumer, kind=SlotKind.INPUT, arg_index=0))
+
+    if len(slots) < 2:
+        return []
+    return [ShareObserverInstance(_slots=frozenset(slots))]
+
+
+# Facts about the data rather than choices about it, so they hold on the far
+# side of a shape-only op. DTYPE is excluded: it is a config decision.
+_DATA_FACT_FIELDS: frozenset = frozenset({FieldName.QSCHEME, FieldName.FLOAT_RANGE})
+
+
+def _rank_changing_passthrough_constraints(
+    node: fx.Node, qspecs: ProvisionalQSpecMap, ctx: _AnnotationContext
+) -> list[Constraint]:
+    """Copy data facts from one end of a rank-changing shape-only chain to the other.
+
+    These ops alter no values, so a fact proven upstream holds downstream; but
+    they change rank, so the ends cannot share an observer. Resolved chain-wise
+    because the intermediate ops hold no fields to carry a fact hop by hop.
+    """
+    source = _chain_source_slot(node, qspecs)
+    if source is None:
+        return []
+    targets = _chain_target_slots(node, qspecs)
+    if not targets:
+        return []
+    return [
+        InheritFields(
+            source=source, targets=frozenset(targets), fields=_DATA_FACT_FIELDS
+        )
+    ]
+
+
+def _chain_source_slot(
+    node: fx.Node, qspecs: ProvisionalQSpecMap
+) -> NodeSlot | None:
+    """Walk upstream past rank-changing passthroughs to the slot holding the facts,
+    or ``None`` if nothing on the chain has any yet.
+    """
+    current = node
+    seen: set[fx.Node] = set()
+    while current.all_input_nodes and current not in seen:
+        seen.add(current)
+        producer = current.all_input_nodes[0]
+        candidate = NodeSlot(node=producer, kind=SlotKind.OUTPUT, arg_index=0)
+        if candidate in qspecs:
+            return candidate
+        if _passthrough_kind(producer) is not _RANK_CHANGING_PASSTHROUGH_OPS:
+            # Not a passthrough and not seeded — the chain has no source.
+            return None
+        current = producer
+    return None
+
+
+def _chain_target_slots(
+    node: fx.Node, qspecs: ProvisionalQSpecMap
+) -> set[NodeSlot]:
+    """Walk downstream past rank-changing passthroughs to the slots that hold observers."""
+    targets: set[NodeSlot] = set()
+    frontier = [node]
+    seen: set[fx.Node] = set()
+    while frontier:
+        current = frontier.pop()
+        if current in seen:
+            continue
+        seen.add(current)
+        for consumer in current.users:
+            consumer_input = _find_input_slot_for_producer(consumer, current)
+            if consumer_input is not None and consumer_input in qspecs:
+                targets.add(consumer_input)
+            elif _passthrough_kind(consumer) is _RANK_CHANGING_PASSTHROUGH_OPS:
+                frontier.append(consumer)
+    return targets
+
+
+# ---------------------------------------------------------------------------
+# Pattern coverage helper.
+# ---------------------------------------------------------------------------
+
+
+def _nodes_covered_by(match_info: Any) -> list[fx.Node]:
+    """Return every fx node an annotator match annotates: the ops it spans.
+
+    Reads ``nodes_map`` rather than ``name_node_map``, which is a projection of it
+    through role names: an in-place activation aliases several roles onto one node,
+    leaving the op it overwrote with no role and so unreachable.
+
+    ``nodes_map`` keys are pattern nodes, so selecting on them excludes operands
+    however they resolve in the model — a compressed weight resolves to a
+    ``call_function`` — and skips the ``None`` standing for an absent one.
+    """
+    match = match_info.annotator_match
+
+    if isinstance(match, InternalMatch):
+        return [
+            model_node
+            for pattern_node, model_node in match.nodes_map.items()
+            if pattern_node.op not in _OPERAND_NODE_OPS
+        ]
+
+    if isinstance(match, tuple) and all(
+        isinstance(partition, SourcePartition) for partition in match
+    ):
+        return [_get_call_function_node_from_partition(partition) for partition in match]
+
+    raise TypeError(
+        f"Unknown annotator match type: {type(match).__name__}. Update "
+        f"_nodes_covered_by when adding a new pattern family."
+    )

--- a/src/coreai_opt/quantization/_graph/_qspec_constraint_generation.py
+++ b/src/coreai_opt/quantization/_graph/_qspec_constraint_generation.py
@@ -143,9 +143,7 @@ def _generate_constraints_for_node(
 
     pattern_class = ctx.shared_observer_nodes.get(node)
     if pattern_class is not None:
-        constraints.extend(
-            pattern_class.generate_qspec_sharing_constraints(node, qspecs)
-        )
+        constraints.extend(pattern_class.generate_qspec_sharing_constraints(node, qspecs))
 
     if _is_state_node(node) and len(node.users) >= 2:
         constraints.extend(_shared_state_constraints(node, qspecs, ctx))
@@ -194,9 +192,7 @@ def _adjacent_edge_constraints(
         producer_output = NodeSlot(node=producer, kind=SlotKind.OUTPUT, arg_index=0)
         consumer_input = NodeSlot(node=node, kind=SlotKind.INPUT, arg_index=arg_index)
         if _edge_should_share(producer_output, consumer_input, qspecs):
-            constraints.append(
-                ShareObserverInstance(frozenset({producer_output, consumer_input}))
-            )
+            constraints.append(ShareObserverInstance(frozenset({producer_output, consumer_input})))
 
     # Outgoing edges.
     for consumer in node.users:
@@ -209,16 +205,12 @@ def _adjacent_edge_constraints(
             continue
         producer_output = NodeSlot(node=node, kind=SlotKind.OUTPUT, arg_index=0)
         if _edge_should_share(producer_output, consumer_input, qspecs):
-            constraints.append(
-                ShareObserverInstance(frozenset({producer_output, consumer_input}))
-            )
+            constraints.append(ShareObserverInstance(frozenset({producer_output, consumer_input})))
 
     return constraints
 
 
-def _edge_should_share(
-    first: NodeSlot, second: NodeSlot, qspecs: ProvisionalQSpecMap
-) -> bool:
+def _edge_should_share(first: NodeSlot, second: NodeSlot, qspecs: ProvisionalQSpecMap) -> bool:
     """Whether an edge's slots should share an observer: neither declined, and at
     least one holding fields.
 
@@ -228,15 +220,10 @@ def _edge_should_share(
     first_qspec, second_qspec = qspecs.get(first), qspecs.get(second)
     if any(qspec is not None and qspec.declined for qspec in (first_qspec, second_qspec)):
         return False
-    return any(
-        qspec is not None and bool(qspec.fields)
-        for qspec in (first_qspec, second_qspec)
-    )
+    return any(qspec is not None and bool(qspec.fields) for qspec in (first_qspec, second_qspec))
 
 
-def _find_input_slot_for_producer(
-    consumer: fx.Node, producer: fx.Node
-) -> NodeSlot | None:
+def _find_input_slot_for_producer(consumer: fx.Node, producer: fx.Node) -> NodeSlot | None:
     """Return the consumer's INPUT slot reading from ``producer``, if any."""
     for arg_index, actual_producer in enumerate(consumer.all_input_nodes):
         if actual_producer is producer:
@@ -273,9 +260,7 @@ def _shared_state_constraints(
         return []
     # Each consumer's config independently says whether it quantizes the tensor,
     # so ordinary config precedence decides — including when it declines.
-    return [
-        ShareObserverInstance(frozenset(known_slots), priority_decides_decline=True)
-    ]
+    return [ShareObserverInstance(frozenset(known_slots), priority_decides_decline=True)]
 
 
 # ---------------------------------------------------------------------------
@@ -336,16 +321,10 @@ def _rank_changing_passthrough_constraints(
     targets = _chain_target_slots(node, qspecs)
     if not targets:
         return []
-    return [
-        InheritFields(
-            source=source, targets=frozenset(targets), fields=_DATA_FACT_FIELDS
-        )
-    ]
+    return [InheritFields(source=source, targets=frozenset(targets), fields=_DATA_FACT_FIELDS)]
 
 
-def _chain_source_slot(
-    node: fx.Node, qspecs: ProvisionalQSpecMap
-) -> NodeSlot | None:
+def _chain_source_slot(node: fx.Node, qspecs: ProvisionalQSpecMap) -> NodeSlot | None:
     """Walk upstream past rank-changing passthroughs to the slot holding the facts,
     or ``None`` if nothing on the chain has any yet.
     """
@@ -364,9 +343,7 @@ def _chain_source_slot(
     return None
 
 
-def _chain_target_slots(
-    node: fx.Node, qspecs: ProvisionalQSpecMap
-) -> set[NodeSlot]:
+def _chain_target_slots(node: fx.Node, qspecs: ProvisionalQSpecMap) -> set[NodeSlot]:
     """Walk downstream past rank-changing passthroughs to the slots that hold observers."""
     targets: set[NodeSlot] = set()
     frontier = [node]

--- a/src/coreai_opt/quantization/_graph/_qspec_constraints.py
+++ b/src/coreai_opt/quantization/_graph/_qspec_constraints.py
@@ -1,0 +1,357 @@
+# Copyright 2026 Apple Inc.
+#
+# Use of this source code is governed by a BSD-3-Clause license that can
+# be found in the LICENSE file or at https://opensource.org/licenses/BSD-3-Clause
+
+"""Constraint types, and the per-field policies used to reconcile them."""
+
+from __future__ import annotations
+
+import logging
+from abc import ABC, abstractmethod
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import Any
+
+from ._qspec_types import (
+    FieldName,
+    FieldValue,
+    NodeSlot,
+    ProvisionalQSpec,
+    ProvisionalQSpecMap,
+    ReconciliationError,
+)
+
+logger = logging.getLogger(__name__)
+
+
+_ALL_FIELDS: frozenset[FieldName] = frozenset(FieldName)
+
+
+# ---------------------------------------------------------------------------
+# Constraint ABC + implementations.
+# ---------------------------------------------------------------------------
+
+
+class Constraint(ABC):
+    """A relation over slots.
+
+    :meth:`apply` enforces the relation and returns the slots it changed. An
+    empty set means it was already satisfied, which is how the drain loop knows
+    when to stop.
+    """
+
+    @property
+    @abstractmethod
+    def slots(self) -> frozenset[NodeSlot]: ...
+
+    @abstractmethod
+    def apply(self, qspecs: ProvisionalQSpecMap) -> set[NodeSlot]: ...
+
+
+@dataclass(frozen=True)
+class ShareFields(Constraint):
+    """Every slot in ``slots`` must agree on each of ``fields``.
+
+    Reconciled per field (:func:`_reconcile_field`), then the winner is written
+    to every slot. The result carries the highest priority among the proposals,
+    which only ever rises — that is why the drain terminates.
+    """
+
+    _slots: frozenset[NodeSlot]
+    fields: frozenset[FieldName]
+
+    @property
+    def slots(self) -> frozenset[NodeSlot]:
+        return self._slots
+
+    def apply(self, qspecs: ProvisionalQSpecMap) -> set[NodeSlot]:
+        changed: set[NodeSlot] = set()
+        for field_name in self.fields:
+            reconciled = _reconcile_field(field_name, self._slots, qspecs)
+            if reconciled is None:
+                continue
+            for slot in self._slots:
+                qspec = _get_or_create(qspecs, slot)
+                current = qspec.fields.get(field_name)
+                if _field_value_stronger(reconciled, current):
+                    qspec.fields[field_name] = reconciled
+                    changed.add(slot)
+        return changed
+
+
+@dataclass(frozen=True)
+class InheritFields(Constraint):
+    """``targets`` take ``source``'s value for each of ``fields``, verbatim.
+
+    A one-way copy, for slots on the same tensor that cannot share an observer
+    because their ranks differ. :class:`ShareFields` reconciles bidirectionally,
+    so a downstream default would widen the upstream value instead of adopting
+    it. ``fields`` should name only facts about the data, never config choices.
+
+    Copies at unchanged priority, so it terminates on the fx graph being a DAG
+    rather than on priority rising.
+    """
+
+    source: NodeSlot
+    targets: frozenset[NodeSlot]
+    fields: frozenset[FieldName]
+
+    @property
+    def slots(self) -> frozenset[NodeSlot]:
+        return self.targets | {self.source}
+
+    def apply(self, qspecs: ProvisionalQSpecMap) -> set[NodeSlot]:
+        source_qspec = qspecs.get(self.source)
+        if source_qspec is None or source_qspec.declined:
+            # Nothing established to carry.
+            return set()
+
+        changed: set[NodeSlot] = set()
+        for field_name in self.fields:
+            source_value = source_qspec.fields.get(field_name)
+            if source_value is None:
+                continue
+            for target in self.targets:
+                target_qspec = qspecs.get(target)
+                if target_qspec is None or target_qspec.declined:
+                    # Only slots that already hold fields, and are not opted
+                    # out, can inherit.
+                    continue
+                if target_qspec.fields.get(field_name) == source_value:
+                    continue
+                target_qspec.fields[field_name] = source_value
+                changed.add(target)
+        return changed
+
+
+@dataclass(frozen=True)
+class ShareObserverInstance(Constraint):
+    """Every slot in ``slots`` shares one :class:`ProvisionalQSpec`, and so one
+    observer at runtime.
+
+    Applying widens the group to anything already sharing a spec with a member,
+    reconciles every field across it, and points all of them at one spec.
+
+    ``priority_decides_decline`` selects how a declined member is resolved:
+
+    * ``False`` (default) — a decline only takes effect if every member declines.
+      For slots tied by op semantics, which are one tensor of one op: disabling
+      an op's output while its input is quantized (or the reverse) is not a
+      coherent instruction, so quantization wins either way.
+    * ``True`` — the highest-priority proposal decides, decline or not. For one
+      tensor read by several ops, where each consumer's config independently
+      says whether it quantizes, so ordinary config precedence applies.
+    """
+
+    _slots: frozenset[NodeSlot]
+    priority_decides_decline: bool = False
+
+    @property
+    def slots(self) -> frozenset[NodeSlot]:
+        return self._slots
+
+    def apply(self, qspecs: ProvisionalQSpecMap) -> set[NodeSlot]:
+        # Widen to anything already sharing a spec with a member.
+        target_ids = {id(qspecs[slot]) for slot in self._slots if slot in qspecs}
+        widened: set[NodeSlot] = set(self._slots)
+        for slot, qspec in qspecs.items():
+            if id(qspec) in target_ids:
+                widened.add(slot)
+
+        group_declined_by = self._resolve_decline(widened, qspecs)
+
+        reconciled_fields: dict[FieldName, FieldValue] = {}
+        for field_name in _ALL_FIELDS:
+            reconciled = _reconcile_field(field_name, frozenset(widened), qspecs)
+            if reconciled is not None:
+                reconciled_fields[field_name] = reconciled
+
+        # Reuse a member's spec when it already matches, so a settled group
+        # reports no change.
+        shared = next(
+            (
+                qspecs[slot]
+                for slot in widened
+                if slot in qspecs
+                and qspecs[slot].fields == reconciled_fields
+                and qspecs[slot].declined_by == group_declined_by
+            ),
+            None,
+        )
+        if shared is None:
+            shared = ProvisionalQSpec(
+                fields=dict(reconciled_fields), declined_by=group_declined_by
+            )
+
+        changed = {slot for slot in widened if qspecs.get(slot) is not shared}
+        for slot in changed:
+            qspecs[slot] = shared
+        return changed
+
+    def _resolve_decline(
+        self, widened: set[NodeSlot], qspecs: ProvisionalQSpecMap
+    ) -> int | None:
+        """Priority of the decline that governs the group, or ``None`` if observed."""
+        declines = [
+            qspecs[slot].declined_by
+            for slot in widened
+            if slot in qspecs and qspecs[slot].declined
+        ]
+        if not declines:
+            return None
+        best_decline = min(declines)
+
+        active_priorities = [
+            value.priority
+            for slot in widened
+            if slot in qspecs
+            for value in qspecs[slot].fields.values()
+        ]
+        if not active_priorities:
+            return best_decline
+        if not self.priority_decides_decline:
+            return None
+        # Ties go to the decline, matching the pre-reconciler behavior where the
+        # highest-priority consumer decided for the whole shared tensor.
+        return best_decline if best_decline <= min(active_priorities) else None
+
+
+# ---------------------------------------------------------------------------
+# Per-field reconciliation.
+# ---------------------------------------------------------------------------
+
+
+def _reconcile_field(
+    field_name: FieldName, slots: frozenset[NodeSlot], qspecs: ProvisionalQSpecMap
+) -> FieldValue | None:
+    """Reconcile one field across ``slots``, or ``None`` if no slot proposed it."""
+    proposals = [
+        qspecs[slot].fields[field_name]
+        for slot in slots
+        if slot in qspecs and field_name in qspecs[slot].fields
+    ]
+    if not proposals:
+        return None
+    policy = _FIELD_POLICY[field_name]
+    return policy(proposals)
+
+
+def _priority_min(proposals: Sequence[FieldValue]) -> int:
+    """Highest priority (lowest priority-number) among the proposals."""
+    return min(proposal.priority for proposal in proposals)
+
+
+def _tie_break_key(proposal: FieldValue) -> tuple[int, str]:
+    """Sort key picking the highest-priority proposal.
+
+    Proposals are gathered from a ``frozenset``, whose order follows identity
+    hashes, so breaking ties on ``str(value)`` is what makes the same model
+    quantize the same way twice.
+    """
+    return (proposal.priority, str(proposal.value))
+
+
+def _policy_priority_wins(proposals: Sequence[FieldValue]) -> FieldValue:
+    """Highest-priority proposal wins; ties broken by :func:`_tie_break_key`."""
+    winner = min(proposals, key=_tie_break_key)
+    return FieldValue(value=winner.value, priority=_priority_min(proposals))
+
+
+def _policy_must_agree(proposals: Sequence[FieldValue]) -> FieldValue:
+    """All values must be equal, else :class:`ReconciliationError`."""
+    values = {proposal.value for proposal in proposals}
+    if len(values) > 1:
+        raise ReconciliationError(
+            f"Incompatible values across slots: {sorted(str(value) for value in values)}. "
+            f"Proposals: {[(proposal.value, proposal.priority) for proposal in proposals]}"
+        )
+    return FieldValue(value=next(iter(values)), priority=_priority_min(proposals))
+
+
+def _policy_qscheme_priority_wins(proposals: Sequence[FieldValue]) -> FieldValue:
+    """Highest-priority proposal wins; ``None`` proposals are ignored.
+
+    Not a join over "looseness", which would override config precedence: for
+    ``A -> B`` with symmetric on ``A``'s output and asymmetric on ``B``'s input,
+    a join picks asymmetric however the user ranked them. Op semantics still win
+    by carrying :data:`OP_INTRINSIC_PRIORITY`.
+    """
+    stated = [proposal for proposal in proposals if proposal.value is not None]
+    if not stated:
+        return FieldValue(value=None, priority=_priority_min(proposals))
+    winner = min(stated, key=_tie_break_key)
+    return FieldValue(value=winner.value, priority=_priority_min(proposals))
+
+
+def _policy_float_range_union(proposals: Sequence[FieldValue]) -> FieldValue:
+    """Union of the proposed ranges, where ``None`` means "learn from data" and
+    so beats any concrete bound.
+
+        [0.0, 1.0]  ⊔  [None, None]  =  [None, None]
+        [0.0, 1.0]  ⊔  [-1.0, 1.0]   =  [-1.0, 1.0]
+        [0.0, None] ⊔  [0.0, None]   =  [0.0, None]
+
+    Priority is ignored: one observer has to cover every slot sharing it.
+    """
+    ranges = [proposal.value for proposal in proposals if proposal.value is not None]
+    if not ranges:
+        return FieldValue(value=None, priority=_priority_min(proposals))
+
+    lows = [r[0] for r in ranges]
+    highs = [r[1] for r in ranges]
+    # An unpinned bound is wider than any pinned one, so it wins.
+    low = None if any(v is None for v in lows) else min(lows)
+    high = None if any(v is None for v in highs) else max(highs)
+    united = [low, high]
+
+    relaxed = [r for r in ranges if list(r) != united]
+    if relaxed:
+        logger.info(
+            "FLOAT_RANGE: pinned range(s) %r relaxed to %r so one observer "
+            "covers every slot sharing it.",
+            relaxed,
+            united,
+        )
+    return FieldValue(value=united, priority=_priority_min(proposals))
+
+
+_FIELD_POLICY: dict[FieldName, Any] = {
+    # Config precedence decides every field except the analytic range.
+    FieldName.DTYPE: _policy_priority_wins,
+    FieldName.QSCHEME: _policy_qscheme_priority_wins,
+    FieldName.QFORMULATION: _policy_priority_wins,
+    FieldName.GRANULARITY: _policy_priority_wins,
+    FieldName.FAKE_QUANTIZE_CLS: _policy_priority_wins,
+    FieldName.QPARAM_CALCULATOR_CLS: _policy_priority_wins,
+    FieldName.RANGE_CALCULATOR_CLS: _policy_priority_wins,
+    FieldName.SCALE_DTYPE: _policy_priority_wins,
+    # Covering every member's values is a correctness constraint, not a
+    # preference, so this one unions instead of deferring to priority.
+    FieldName.FLOAT_RANGE: _policy_float_range_union,
+    # Weight and activation slots do share observers — flatten(param) -> add
+    # ties a WEIGHT input slot to an ACTIVATION output slot — so this needs
+    # resolving. Priority keeps every field coming from one winning config.
+    FieldName.QUANTIZATION_TARGET: _policy_priority_wins,
+}
+
+
+def _field_value_stronger(new: FieldValue, current: FieldValue | None) -> bool:
+    """Whether writing ``new`` would change the value or raise its priority."""
+    if current is None:
+        return True
+    if new.value != current.value:
+        return True
+    return new.priority < current.priority
+
+
+# ---------------------------------------------------------------------------
+# Helpers.
+# ---------------------------------------------------------------------------
+
+
+def _get_or_create(qspecs: ProvisionalQSpecMap, slot: NodeSlot) -> ProvisionalQSpec:
+    """Return the :class:`ProvisionalQSpec` for ``slot``, creating one if absent."""
+    if slot not in qspecs:
+        qspecs[slot] = ProvisionalQSpec()
+    return qspecs[slot]

--- a/src/coreai_opt/quantization/_graph/_qspec_constraints.py
+++ b/src/coreai_opt/quantization/_graph/_qspec_constraints.py
@@ -180,23 +180,17 @@ class ShareObserverInstance(Constraint):
             None,
         )
         if shared is None:
-            shared = ProvisionalQSpec(
-                fields=dict(reconciled_fields), declined_by=group_declined_by
-            )
+            shared = ProvisionalQSpec(fields=dict(reconciled_fields), declined_by=group_declined_by)
 
         changed = {slot for slot in widened if qspecs.get(slot) is not shared}
         for slot in changed:
             qspecs[slot] = shared
         return changed
 
-    def _resolve_decline(
-        self, widened: set[NodeSlot], qspecs: ProvisionalQSpecMap
-    ) -> int | None:
+    def _resolve_decline(self, widened: set[NodeSlot], qspecs: ProvisionalQSpecMap) -> int | None:
         """Priority of the decline that governs the group, or ``None`` if observed."""
         declines = [
-            qspecs[slot].declined_by
-            for slot in widened
-            if slot in qspecs and qspecs[slot].declined
+            qspecs[slot].declined_by for slot in widened if slot in qspecs and qspecs[slot].declined
         ]
         if not declines:
             return None

--- a/src/coreai_opt/quantization/_graph/_qspec_reconcile.py
+++ b/src/coreai_opt/quantization/_graph/_qspec_reconcile.py
@@ -1,0 +1,83 @@
+# Copyright 2026 Apple Inc.
+#
+# Use of this source code is governed by a BSD-3-Clause license that can
+# be found in the LICENSE file or at https://opensource.org/licenses/BSD-3-Clause
+
+"""Driver for graph-mode quantization annotation.
+
+:func:`annotate_via_reconciliation` seeds a provisional qspec per quantizable
+tensor, drains a queue of constraints over them to a fixed point, and writes the
+result onto the graph. Each of those steps lives in a ``_qspec_*`` sibling.
+
+See ``docs/architecture_notes/graph_annotation.md`` for the reasoning.
+"""
+
+from __future__ import annotations
+
+from collections import deque
+
+import torch.fx as fx
+
+from ._provisional_qspec_generation import build_initial_provisional_qspecs
+from ._qspec_constraint_generation import (
+    _AnnotationContext,
+    _generate_constraints_for_node,
+    _nodes_covered_by,
+)
+from ._qspec_constraints import Constraint
+from ._qspec_resolution import resolve_qspecs
+
+# Re-export so callers depend only on _qspec_reconcile.
+__all__ = [
+    "_AnnotationContext",
+    "_nodes_covered_by",
+    "annotate_via_reconciliation",
+]
+
+_MAX_ITERS_PER_SLOT = 100
+"""Drain-loop iteration budget per slot. See :func:`_drain_iteration_bound`."""
+
+
+def annotate_via_reconciliation(
+    model: fx.GraphModule, ctx: _AnnotationContext
+) -> None:
+    """Annotate ``model`` in place using the constraint-queue reconciler."""
+    qspecs = build_initial_provisional_qspecs(
+        winning_configs=ctx.winning_configs,
+        node_priorities=ctx.node_priorities,
+        pattern_groups=ctx.pattern_groups,
+        module_name_to_state_names_map=ctx.module_name_to_state_names_map,
+        primary_nodes=ctx.primary_nodes,
+    )
+
+    queue: deque[Constraint] = deque()
+    for node in model.graph.nodes:
+        queue.extend(_generate_constraints_for_node(node, qspecs, ctx))
+
+    max_iters = _drain_iteration_bound(model)
+    iters = 0
+    while queue:
+        constraint = queue.popleft()
+        changed = constraint.apply(qspecs)
+        iters += 1
+        if iters > max_iters:
+            raise RuntimeError(
+                f"Constraint reconciliation exceeded budget of {max_iters} iterations"
+            )
+        touched_nodes = {slot.node for slot in changed}
+        for touched in touched_nodes:
+            queue.extend(_generate_constraints_for_node(touched, qspecs, ctx))
+
+    resolve_qspecs(model, qspecs)
+
+
+def _drain_iteration_bound(model: fx.GraphModule) -> int:
+    """Iteration budget for the drain loop: ``100 * slots``.
+
+    The theoretical bound is O(#nodes * #slots * #fields), but measured usage is
+    about one iteration per slot, so this takes the empirical shape with a
+    generous constant. Exceeding it means something is wrong.
+    """
+
+    slots = sum(1 + len(node.all_input_nodes) for node in model.graph.nodes)
+    return _MAX_ITERS_PER_SLOT * max(slots, 1)

--- a/src/coreai_opt/quantization/_graph/_qspec_reconcile.py
+++ b/src/coreai_opt/quantization/_graph/_qspec_reconcile.py
@@ -38,9 +38,7 @@ _MAX_ITERS_PER_SLOT = 100
 """Drain-loop iteration budget per slot. See :func:`_drain_iteration_bound`."""
 
 
-def annotate_via_reconciliation(
-    model: fx.GraphModule, ctx: _AnnotationContext
-) -> None:
+def annotate_via_reconciliation(model: fx.GraphModule, ctx: _AnnotationContext) -> None:
     """Annotate ``model`` in place using the constraint-queue reconciler."""
     qspecs = build_initial_provisional_qspecs(
         winning_configs=ctx.winning_configs,

--- a/src/coreai_opt/quantization/_graph/_qspec_resolution.py
+++ b/src/coreai_opt/quantization/_graph/_qspec_resolution.py
@@ -1,0 +1,272 @@
+# Copyright 2026 Apple Inc.
+#
+# Use of this source code is governed by a BSD-3-Clause license that can
+# be found in the LICENSE file or at https://opensource.org/licenses/BSD-3-Clause
+
+"""Write the settled :class:`ProvisionalQSpecMap` onto the fx graph as
+:class:`QuantizationAnnotation` entries.
+
+Sharing is already expressed as slots pointing at one
+:class:`ProvisionalQSpec`, so the work is projecting that onto torchao's per-node
+model: group by spec identity, pick a topologically-first anchor per group, give
+the anchor a concrete spec and the rest a :class:`SharedQuantizationSpec`
+pointing at it, then bucket per node and write.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from dataclasses import dataclass
+
+import torch.fx as fx
+from torchao.quantization.pt2e.quantizer import (
+    QuantizationAnnotation,
+    QuantizationSpec as TorchAOQuantizationSpec,
+    SharedQuantizationSpec as _SharedQuantizationSpec,
+)
+from torchao.quantization.pt2e.quantizer.quantizer import Q_ANNOTATION_KEY
+
+from coreai_opt.quantization.spec import QuantizationSpec
+
+from ._annotation_config import AnnotationConfig
+from ._qspec_types import (
+    FieldName,
+    NodeSlot,
+    ProvisionalQSpec,
+    ProvisionalQSpecMap,
+    ReconciliationError,
+    SlotKind,
+)
+
+# Reused verbatim, so a reconciled spec converts by the same path as a
+# configured one.
+_convert_to_pt2e_spec = AnnotationConfig._convert_to_pt2e_spec
+
+# A concrete spec on a group's anchor slot; a SharedQuantizationSpec pointing at
+# the anchor on every other slot.
+_SlotSpec = TorchAOQuantizationSpec | _SharedQuantizationSpec
+
+# ---------------------------------------------------------------------------
+# Entry point.
+# ---------------------------------------------------------------------------
+
+
+def resolve_qspecs(model: fx.GraphModule, qspecs: ProvisionalQSpecMap) -> None:
+    """Project reconciled per-slot state onto ``model``'s annotations, in place."""
+    groups = _group_slots_by_qspec_identity(qspecs)
+    topo_index = _topo_index(model)
+
+    slot_assignments: dict[NodeSlot, _SlotSpec] = {}
+    for group in groups:
+        _assign_group_specs(group, topo_index, slot_assignments)
+
+    per_node_inputs, per_node_outputs = _bucket_per_node(slot_assignments)
+    _write_annotations(per_node_inputs, per_node_outputs)
+
+
+# ---------------------------------------------------------------------------
+# Grouping.
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _QSpecGroup:
+    """Slots that all point at one :class:`ProvisionalQSpec`."""
+
+    qspec: ProvisionalQSpec
+    slots: list[NodeSlot]
+
+
+def _group_slots_by_qspec_identity(qspecs: ProvisionalQSpecMap) -> list[_QSpecGroup]:
+    """Bucket slots by ``id(ProvisionalQSpec)`` — same object = same group."""
+    groups_by_id: dict[int, _QSpecGroup] = {}
+    for slot, qspec in qspecs.items():
+        group = groups_by_id.get(id(qspec))
+        if group is None:
+            group = _QSpecGroup(qspec=qspec, slots=[])
+            groups_by_id[id(qspec)] = group
+        group.slots.append(slot)
+    return list(groups_by_id.values())
+
+
+# ---------------------------------------------------------------------------
+# Anchor selection.
+# ---------------------------------------------------------------------------
+
+
+@dataclass(order=True, frozen=True)
+class SlotOrderKey:
+    """Sort key for picking a shared-observer group's anchor.
+
+    Attributes:
+        topo_index (int): Position in ``model.graph.nodes``. Torchao walks nodes
+            in this order, so the anchor's observer must be registered before
+            anything can reference it.
+        kind_order (int): INPUT (0) before OUTPUT (1), matching the order
+            ``_get_edge_or_node_to_qspec`` iterates a node's slots.
+        arg_index (int): Tiebreaker among INPUT slots.
+    """
+
+    topo_index: int
+    kind_order: int
+    arg_index: int
+
+
+def _topo_index(model: fx.GraphModule) -> dict[fx.Node, int]:
+    return {node: i for i, node in enumerate(model.graph.nodes)}
+
+
+def _slot_order_key(slot: NodeSlot, topo_index: dict[fx.Node, int]) -> SlotOrderKey:
+    return SlotOrderKey(
+        topo_index=topo_index.get(slot.node, len(topo_index)),
+        kind_order=0 if slot.kind is SlotKind.INPUT else 1,
+        arg_index=slot.arg_index,
+    )
+
+
+def _pick_anchor(group: _QSpecGroup, topo_index: dict[fx.Node, int]) -> NodeSlot:
+    """Return the topologically-first slot in ``group``, per :class:`SlotOrderKey`."""
+    return min(group.slots, key=lambda slot: _slot_order_key(slot, topo_index))
+
+
+# ---------------------------------------------------------------------------
+# Spec assignment.
+# ---------------------------------------------------------------------------
+
+
+def _assign_group_specs(
+    group: _QSpecGroup,
+    topo_index: dict[fx.Node, int],
+    slot_assignments: dict[NodeSlot, _SlotSpec],
+) -> None:
+    """Fill ``slot_assignments`` with the spec each slot in ``group`` carries: the
+    concrete spec on the anchor, a :class:`SharedQuantizationSpec` on the rest.
+    """
+    concrete = _build_concrete_spec(group.qspec)
+    if concrete is None:
+        # Nothing to annotate.
+        return
+    if len(group.slots) == 1:
+        slot_assignments[group.slots[0]] = concrete
+        return
+
+    anchor = _pick_anchor(group, topo_index)
+    shared_ref = _shared_spec_pointing_at(anchor)
+    for slot in group.slots:
+        slot_assignments[slot] = concrete if slot == anchor else shared_ref
+
+
+def _shared_spec_pointing_at(anchor: NodeSlot) -> _SharedQuantizationSpec:
+    """Build a :class:`SharedQuantizationSpec` in the form torchao registered
+    ``anchor``'s observer under: by node for an output, by edge for an input.
+    """
+    if anchor.kind is SlotKind.OUTPUT:
+        return _SharedQuantizationSpec(anchor.node)
+    producer = anchor.node.all_input_nodes[anchor.arg_index]
+    return _SharedQuantizationSpec((producer, anchor.node))
+
+
+# The other half of _provisional_qspec_generation._FIELD_FROM_SPEC_ATTR: the two
+# make up the round trip between a spec and its decomposed fields.
+_SPEC_KWARG_FROM_FIELD: dict[FieldName, str] = {
+    FieldName.DTYPE: "dtype",
+    FieldName.QSCHEME: "qscheme",
+    FieldName.QFORMULATION: "qformulation",
+    FieldName.GRANULARITY: "granularity",
+    FieldName.FLOAT_RANGE: "float_range",
+    FieldName.FAKE_QUANTIZE_CLS: "fake_quantize_cls",
+    FieldName.QPARAM_CALCULATOR_CLS: "qparam_calculator_cls",
+    FieldName.RANGE_CALCULATOR_CLS: "range_calculator_cls",
+    FieldName.SCALE_DTYPE: "scale_dtype",
+}
+
+
+def _build_concrete_spec(qspec: ProvisionalQSpec) -> TorchAOQuantizationSpec | None:
+    """Reassemble a :class:`QuantizationSpec` from reconciled fields and convert it
+    for torchao. ``None`` when the group is declined or holds no fields.
+
+    Building the observer here, from settled values, is what makes the field map
+    the source of truth — the qscheme that takes effect is the one inside the
+    observer's qparams calculator.
+    """
+    if qspec.declined:
+        # No annotation, so torchao leaves the op in float. Upstream producers
+        # keep their observers, so their branches dequantize into it.
+        return None
+    if not qspec.fields:
+        return None
+    missing = [
+        field_name.name
+        for field_name in _SPEC_KWARG_FROM_FIELD
+        if field_name not in qspec.fields
+    ]
+    if missing or FieldName.QUANTIZATION_TARGET not in qspec.fields:
+        # Every observed slot is seeded from a whole QuantizationSpec, so a
+        # partial group is a generation bug. Don't paper over it with defaults.
+        raise ReconciliationError(
+            f"Cannot rebuild a QuantizationSpec: reconciled group is missing "
+            f"{missing or ['QUANTIZATION_TARGET']}. Present: "
+            f"{sorted(f.name for f in qspec.fields)}."
+        )
+
+    spec = QuantizationSpec(
+        **{
+            kwarg: qspec.fields[field_name].value
+            for field_name, kwarg in _SPEC_KWARG_FROM_FIELD.items()
+        }
+    )
+    return _convert_to_pt2e_spec(
+        spec, qspec.fields[FieldName.QUANTIZATION_TARGET].value
+    )
+
+
+# ---------------------------------------------------------------------------
+# Per-node bucketing + write.
+# ---------------------------------------------------------------------------
+
+
+def _bucket_per_node(
+    slot_assignments: dict[NodeSlot, _SlotSpec],
+) -> tuple[dict[fx.Node, dict[fx.Node, _SlotSpec]], dict[fx.Node, _SlotSpec]]:
+    """Split per-slot assignments into per-node ``input_qspec_map`` / ``output_qspec``."""
+    per_node_inputs: dict[fx.Node, dict[fx.Node, _SlotSpec]] = defaultdict(dict)
+    per_node_outputs: dict[fx.Node, _SlotSpec] = {}
+    for slot, spec in slot_assignments.items():
+        if slot.kind is SlotKind.OUTPUT:
+            per_node_outputs[slot.node] = spec
+        else:
+            producer = slot.node.all_input_nodes[slot.arg_index]
+            per_node_inputs[slot.node][producer] = spec
+    return per_node_inputs, per_node_outputs
+
+
+def _write_annotations(
+    per_node_inputs: dict[fx.Node, dict[fx.Node, _SlotSpec]],
+    per_node_outputs: dict[fx.Node, _SlotSpec],
+) -> None:
+    """Mutate each touched node's meta with a :class:`QuantizationAnnotation`.
+
+    Input maps are backfilled with ``None`` for unspecified positions, because
+    torchao's later passes index them positionally and IndexError on gaps. An
+    interop concession, not a reconciliation decision.
+    """
+    touched: set[fx.Node] = set(per_node_inputs) | set(per_node_outputs)
+    for node in touched:
+        annotation = node.meta.get(Q_ANNOTATION_KEY, QuantizationAnnotation())
+        input_map = per_node_inputs.get(node)
+        if input_map:
+            annotation.input_qspec_map = _backfill_input_qspec_map(node, input_map)
+        if node in per_node_outputs:
+            annotation.output_qspec = per_node_outputs[node]
+        annotation._annotated = True
+        node.meta[Q_ANNOTATION_KEY] = annotation
+
+
+def _backfill_input_qspec_map(
+    node: fx.Node, input_map: dict[fx.Node, _SlotSpec]
+) -> dict[fx.Node, _SlotSpec | None]:
+    """An ``input_qspec_map`` with an entry per positional input, ``None`` where unset."""
+    return {
+        producer: input_map.get(producer, None)
+        for producer in node.all_input_nodes
+    }

--- a/src/coreai_opt/quantization/_graph/_qspec_resolution.py
+++ b/src/coreai_opt/quantization/_graph/_qspec_resolution.py
@@ -196,9 +196,7 @@ def _build_concrete_spec(qspec: ProvisionalQSpec) -> TorchAOQuantizationSpec | N
     if not qspec.fields:
         return None
     missing = [
-        field_name.name
-        for field_name in _SPEC_KWARG_FROM_FIELD
-        if field_name not in qspec.fields
+        field_name.name for field_name in _SPEC_KWARG_FROM_FIELD if field_name not in qspec.fields
     ]
     if missing or FieldName.QUANTIZATION_TARGET not in qspec.fields:
         # Every observed slot is seeded from a whole QuantizationSpec, so a
@@ -215,9 +213,7 @@ def _build_concrete_spec(qspec: ProvisionalQSpec) -> TorchAOQuantizationSpec | N
             for field_name, kwarg in _SPEC_KWARG_FROM_FIELD.items()
         }
     )
-    return _convert_to_pt2e_spec(
-        spec, qspec.fields[FieldName.QUANTIZATION_TARGET].value
-    )
+    return _convert_to_pt2e_spec(spec, qspec.fields[FieldName.QUANTIZATION_TARGET].value)
 
 
 # ---------------------------------------------------------------------------
@@ -266,7 +262,4 @@ def _backfill_input_qspec_map(
     node: fx.Node, input_map: dict[fx.Node, _SlotSpec]
 ) -> dict[fx.Node, _SlotSpec | None]:
     """An ``input_qspec_map`` with an entry per positional input, ``None`` where unset."""
-    return {
-        producer: input_map.get(producer, None)
-        for producer in node.all_input_nodes
-    }
+    return {producer: input_map.get(producer, None) for producer in node.all_input_nodes}

--- a/src/coreai_opt/quantization/_graph/_qspec_types.py
+++ b/src/coreai_opt/quantization/_graph/_qspec_types.py
@@ -1,0 +1,136 @@
+# Copyright 2026 Apple Inc.
+#
+# Use of this source code is governed by a BSD-3-Clause license that can
+# be found in the LICENSE file or at https://opensource.org/licenses/BSD-3-Clause
+
+"""Types shared by every phase of the qspec reconciliation pipeline.
+
+Data and enums only, so no phase has to import another just to name a type.
+"""
+
+from __future__ import annotations
+
+import enum
+from dataclasses import dataclass, field
+from typing import Any
+
+import torch.fx as fx
+
+# ---------------------------------------------------------------------------
+# Atomic units.
+# ---------------------------------------------------------------------------
+
+
+class SlotKind(enum.Enum):
+    """Which side of a node a slot lives on."""
+
+    INPUT = enum.auto()
+    OUTPUT = enum.auto()
+
+
+@dataclass(frozen=True)
+class NodeSlot:
+    """One quantization decision point, and the unit reconciliation works on.
+
+    Each node has one ``OUTPUT`` slot (``arg_index=0``) and one ``INPUT`` slot
+    per entry in ``node.all_input_nodes``, indexed by position.
+    """
+
+    node: fx.Node
+    kind: SlotKind
+    arg_index: int
+
+
+class FieldName(enum.Enum):
+    """One per settable input of
+    :class:`coreai_opt.quantization.spec.QuantizationSpec`, plus
+    :attr:`QUANTIZATION_TARGET`. Each reconciles independently, per
+    ``_qspec_constraints._FIELD_POLICY``.
+
+    ``quant_min`` / ``quant_max`` / ``n_bits`` / ``target_dtype`` are absent
+    because ``QuantizationSpec`` derives them from ``dtype`` and ``qscheme``;
+    ``ch_axis`` lives inside :attr:`GRANULARITY`; ``is_dynamic`` is torchao-only.
+    """
+
+    DTYPE = enum.auto()
+    QSCHEME = enum.auto()
+    QFORMULATION = enum.auto()
+    GRANULARITY = enum.auto()  # carries the channel/block axis
+    FLOAT_RANGE = enum.auto()  # analytic [min, max]; either bound may be None
+    FAKE_QUANTIZE_CLS = enum.auto()
+    QPARAM_CALCULATOR_CLS = enum.auto()
+    RANGE_CALCULATOR_CLS = enum.auto()
+    SCALE_DTYPE = enum.auto()
+    # Weight or activation, set by which config dict the spec came from. Not a
+    # QuantizationSpec attribute, but an input to construct_partial alongside
+    # them, so resolution needs it to rebuild the observer.
+    QUANTIZATION_TARGET = enum.auto()
+
+
+@dataclass(frozen=True)
+class FieldValue:
+    """A value proposed for one field, plus the priority it came from.
+
+    Lower number means higher priority, following the sort order. Reconciliation
+    only ever lowers it.
+    """
+
+    value: Any
+    priority: int
+
+
+OP_INTRINSIC_PRIORITY = -1
+"""Reserved priority for proposals from op semantics rather than user config.
+
+Sigmoid's output being confined to ``[0, 1]`` is a fact about the operator, not
+a preference, so it should outrank every user proposal. User priorities are
+positions in the annotation sort order and so ``>= 0``; a negative reserved value
+lets op semantics win under the ordinary "highest priority wins" rule instead of
+a per-field exception.
+"""
+
+
+@dataclass
+class ProvisionalQSpec:
+    """Mutable per-observer state.
+
+    Several slots may reference one instance; that object identity is how
+    ``ShareObserverInstance`` expresses sharing.
+
+    Attributes:
+        fields (dict[FieldName, FieldValue]): Reconciled per-field state.
+        declined_by (int | None): Priority of the config that declined this
+            slot, or ``None``. See :attr:`declined`.
+    """
+
+    fields: dict[FieldName, FieldValue] = field(default_factory=dict)
+    declined_by: int | None = None
+
+    @property
+    def declined(self) -> bool:
+        """Whether a config explicitly opted this slot out of observation.
+
+        Distinct from an empty field map, which means nothing has spoken for the
+        slot — absence cannot outrank an observing peer, but a decline must.
+        """
+        return self.declined_by is not None
+
+
+ProvisionalQSpecMap = dict[NodeSlot, ProvisionalQSpec]
+"""The map every phase reads and writes.
+
+Slots pointing at the same :class:`ProvisionalQSpec` share an observer at
+runtime; slots pointing at distinct ones reconcile independently.
+"""
+
+
+# ---------------------------------------------------------------------------
+# Cross-phase exception.
+# ---------------------------------------------------------------------------
+
+
+class ReconciliationError(RuntimeError):
+    """Raised when reconciliation hits an unresolvable state: a must-agree field
+    whose proposals disagree, or a pattern shape the generation rules can't
+    handle.
+    """

--- a/src/coreai_opt/quantization/_graph/quantizer.py
+++ b/src/coreai_opt/quantization/_graph/quantizer.py
@@ -230,9 +230,7 @@ class _AnnotationHandler(TorchPT2EQuantizer):
             for a_class in self._all_patterns()
             if issubclass(a_class, SharedObserverModulePattern)
         ]
-        shared_observer_nodes: dict[
-            torch.fx.Node, type[SharedObserverModulePattern]
-        ] = {}
+        shared_observer_nodes: dict[torch.fx.Node, type[SharedObserverModulePattern]] = {}
         for annotator in shared_observer_annotators:
             node_to_annotator_and_match_dict = annotator._match_all_patterns(model)
             for node in node_to_annotator_and_match_dict:

--- a/src/coreai_opt/quantization/_graph/quantizer.py
+++ b/src/coreai_opt/quantization/_graph/quantizer.py
@@ -75,15 +75,18 @@ from ._annotation_pattern_registry import (
 )
 from ._annotation_utils import (
     _get_input_qspec_map,
-    adjust_output_qspec_for_qscheme_and_propagate,
     annotate_module_level_specs,
-    is_node_annotated,
 )
 from ._conv_bn_utils import fold_conv_bn_weights, remove_conv_bn_zeros_like_dtype
 from ._prepare_for_export import (
     _move_cache_dequant_to_output,
     prepare_for_mil_export,
     prepare_for_mlir_export,
+)
+from ._qspec_reconcile import (
+    _AnnotationContext,
+    _nodes_covered_by,
+    annotate_via_reconciliation,
 )
 from ._utils import (
     force_per_tensor_for_channel_altering_ops,
@@ -212,22 +215,30 @@ class _AnnotationHandler(TorchPT2EQuantizer):
         """Globally-registered patterns plus per-instance ``extra_patterns``."""
         return list(_AnnotationPatternRegistry.list_registry_values()) + self._extra_patterns
 
-    def _get_shared_observer_nodes(self, model: torch.fx.GraphModule) -> set[torch.fx.Node]:
-        """
-        Return a set of all shared observer nodes in the model.
+    def _get_shared_observer_nodes(
+        self, model: torch.fx.GraphModule
+    ) -> dict[torch.fx.Node, type[SharedObserverModulePattern]]:
+        """Return every shared-observer node in the model, mapped to the
+        pattern class that matched it.
+
+        The pattern class is what owns the node's qspec-sharing semantics
+        (via :meth:`SharedObserverModulePattern.generate_qspec_sharing_constraints`).
+        Callers that only need the node set can take ``.keys()``.
         """
         shared_observer_annotators = [
             a_class
             for a_class in self._all_patterns()
             if issubclass(a_class, SharedObserverModulePattern)
         ]
-        shared_observer_nodes = set()
+        shared_observer_nodes: dict[
+            torch.fx.Node, type[SharedObserverModulePattern]
+        ] = {}
         for annotator in shared_observer_annotators:
             node_to_annotator_and_match_dict = annotator._match_all_patterns(model)
-
-            # We only care about the nodes
             for node in node_to_annotator_and_match_dict:
-                shared_observer_nodes.add(node)
+                # First match wins if multiple patterns claim the same node —
+                # deterministic given registry iteration order.
+                shared_observer_nodes.setdefault(node, annotator)
         return shared_observer_nodes
 
     def annotate(self, model: torch.fx.GraphModule) -> torch.fx.GraphModule:
@@ -247,39 +258,66 @@ class _AnnotationHandler(TorchPT2EQuantizer):
         if not isinstance(model, torch.fx.GraphModule):
             raise TypeError("Model must be a torch.fx.GraphModule")
 
-        # Matching phase - apply all annotators to model
+        # Match all annotator patterns.
         node_to_annotator_match_info_dict = self._match_all_annotators(model)
 
-        # Sorting phase - sort all matches in the order to try annotating in
+        # Sort matches into priority order (config-level > pattern-length > topo).
+        # Used to pick each node's winning config when multiple matches touch it.
         sorted_nodes_with_annotation_match_info = self._sort_nodes_in_annotation_order(
             model, node_to_annotator_match_info_dict
         )
 
-        # Annotation phase - go through sorted nodes with matches list to annotate
-        shared_observer_nodes = self._get_shared_observer_nodes(model)
-        # Build pass-invariant context once; shared by all annotator invocations.
+        # Winning config per node + priority + pattern group. Pattern-match
+        # dicts key on a single primary node but annotate every covered node
+        # (Conv+Sigmoid annotates both conv and sigmoid); expand the coverage
+        # so every covered node has (config, priority, pattern_group) for
+        # its slots. Priority = position in the sorted list (lower = higher
+        # priority); used by reconcile() to break dtype ties within a
+        # shared-observer group.
+        winning_configs: dict[torch.fx.Node, Any] = {}
+        node_priorities: dict[torch.fx.Node, int] = {}
+        pattern_groups: dict[torch.fx.Node, frozenset[torch.fx.Node]] = {}
+        primary_nodes: set[torch.fx.Node] = set()
+        for priority, (primary_node, cfg, match_info) in enumerate(
+            sorted_nodes_with_annotation_match_info
+        ):
+            covered = frozenset(_nodes_covered_by(match_info))
+            for covered_node in covered:
+                if covered_node in winning_configs:
+                    continue  # first (highest-priority) pattern wins
+                winning_configs[covered_node] = cfg
+                node_priorities[covered_node] = priority
+                pattern_groups[covered_node] = covered
+                if covered_node is primary_node:
+                    primary_nodes.add(covered_node)
+
+        shared_observer_node_to_pattern = self._get_shared_observer_nodes(model)
+        # Build pass-invariant AnnotationContext once; still needed for the
+        # kv-cache-override pass below, which reuses the standard annotator
+        # helpers (``_get_input_qspec_map``) to compute its overrides.
         context = AnnotationContext(
             module_name_to_state_names_map=self._module_name_to_state_names_map,
-            shared_observer_nodes=shared_observer_nodes,
         )
-        for node, config, annotator_match_info in sorted_nodes_with_annotation_match_info:
-            if is_node_annotated(node):
-                continue
-            annotation_config = AnnotationConfig.from_quantizer_config(config)
-            annotator_match_info.annotator_func(
-                annotator_match_info.annotator_match,
-                annotation_config,
-                context,
-            )
 
+        # Reconciliation pipeline: every config, op-intrinsic and structural
+        # demand on a tensor becomes a constraint, and a fixed-point loop
+        # settles them. See docs/architecture_notes/graph_annotation.md.
+        ctx = _AnnotationContext(
+            winning_configs=winning_configs,
+            node_priorities=node_priorities,
+            pattern_groups=pattern_groups,
+            primary_nodes=primary_nodes,
+            shared_observer_nodes=shared_observer_node_to_pattern,
+            module_name_to_state_names_map=self._module_name_to_state_names_map,
+        )
+        annotate_via_reconciliation(model, ctx)
+
+        # Module-level input/output/state overrides. TODO: express these as
+        # ordinary constraints so they participate in reconciliation; as a
+        # post-pass they overwrite reconciled specs on module-boundary nodes.
         annotate_module_level_specs(
             self._module_configs, self._module_name_to_state_names_map, model
         )
-
-        # Post-annotation graph pass to go through the model and adjust any qspecs which
-        # are following always affine or fixed range nodes.
-        for node in model.graph.nodes:
-            adjust_output_qspec_for_qscheme_and_propagate(node, shared_observer_nodes)
 
         # Force-apply each cache spec last so it wins over any module-scope
         # annotation that may have claimed the cache op via a wildcard. Cache

--- a/src/coreai_opt/quantization/config/quantization_config.py
+++ b/src/coreai_opt/quantization/config/quantization_config.py
@@ -13,7 +13,10 @@ from typing import TYPE_CHECKING, ClassVar, NamedTuple, Self, TypeAlias, final
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
-from coreai_opt._utils.config_utils import ALL_TENSORS as _ALL_TENSORS
+from coreai_opt._utils.config_utils import (
+    ALL_TENSORS as _ALL_TENSORS,
+    spec_dict_is_active as _spec_dict_is_active,
+)
 from coreai_opt.common import (
     _DeprecatedMemberEnumMeta,
     _StrEnum,
@@ -534,7 +537,7 @@ class KVCacheQuantConfig(BaseModel):
         # op_output_spec must be empty/None: the finalize pass synthesizes the
         # output dequantize itself; a user-supplied output spec would either
         # double-quantize or conflict with the relocated dq.
-        if oqc.op_output_spec:
+        if _spec_dict_is_active(oqc.op_output_spec):
             raise ValueError(
                 "KVCacheQuantConfig.op_quantizer_config.op_output_spec must be "
                 "empty or None; the finalize pass inserts the output dequantize."
@@ -542,7 +545,7 @@ class KVCacheQuantConfig(BaseModel):
 
         # op_state_spec must be empty/None: cache-update ops have no learnable
         # state (the cache buffer is an input, not a parameter).
-        if oqc.op_state_spec:
+        if _spec_dict_is_active(oqc.op_state_spec):
             raise ValueError(
                 "KVCacheQuantConfig.op_quantizer_config.op_state_spec must be "
                 "empty or None; cache-update ops have no learnable state."

--- a/tests/pruning/test_pruning_config_and_spec.py
+++ b/tests/pruning/test_pruning_config_and_spec.py
@@ -9,6 +9,7 @@ import pytest
 import torch
 import torch.nn as nn
 
+from coreai_opt._utils.config_utils import spec_dict_is_active
 from coreai_opt.pruning.config import (
     MagnitudePrunerConfig,
     ModuleMagnitudePrunerConfig,
@@ -313,4 +314,4 @@ class TestPruningConfig:
         """Setting global_config to None disables pruning globally."""
         config = MagnitudePrunerConfig(global_config=None)
         assert config.global_config is not None
-        assert not config.global_config.op_state_spec
+        assert not spec_dict_is_active(config.global_config.op_state_spec)

--- a/tests/quantization/test_annotation_pattern_registry.py
+++ b/tests/quantization/test_annotation_pattern_registry.py
@@ -20,7 +20,7 @@ import torch.nn as nn
 from torchao.quantization.pt2e import disable_fake_quant
 from torchao.quantization.pt2e.export_utils import _EXPORTED_TRAINING_ATTR
 
-from coreai_opt._utils.config_utils import ALL_TENSORS as _ALL_TENSORS
+from coreai_opt._utils.config_utils import ALL_TENSORS as _ALL_TENSORS, spec_dict_is_active
 from coreai_opt.quantization import (
     ModuleQuantizerConfig,
     Quantizer,
@@ -1384,8 +1384,13 @@ class TestAnnotationPatternRegistry:
         quantize_nodes = [
             node for node in prepared_model.graph.nodes if "activation_post_process" in node.name
         ]
-        assert len(quantize_nodes) == 1
-        assert quantize_nodes[0] in flatten_node.users.keys()
+        # The output spec outranks the input's None — they are one tensor — so the
+        # flatten is observed at both of its slots by a single quantizer module.
+        assert len(quantize_nodes) == 2
+        assert any(node in flatten_node.users for node in quantize_nodes)
+        assert any(node in flatten_node.all_input_nodes for node in quantize_nodes)
+        modules = {getattr(prepared_model, node.name) for node in quantize_nodes}
+        assert len(modules) == 1
 
     def test_shared_observer_no_qspec_set(self):
         """
@@ -3564,7 +3569,7 @@ class TestAnnotationPatternRegistry:
         add_first_input_quantizer = getattr(prepared_model, add_first_input_node_name)
         assert add_first_input_quantizer.dtype == torch.int8
 
-        if config.global_config.op_state_spec:
+        if spec_dict_is_active(config.global_config.op_state_spec):
             flatten_preceding_quantizer = getattr(prepared_model, flatten_preceding_quantizer_name)
             assert flatten_preceding_quantizer is flatten_succeeding_quantizer
             assert flatten_preceding_quantizer.dtype == torch.int4
@@ -4074,6 +4079,12 @@ class TestAnnotationPattern:
 
                 patterns = [mock_pattern_1]
                 return patterns
+
+            @classmethod
+            def generate_qspec_sharing_constraints(cls, node, qspecs):
+                # Stub — abstract on the base class; unused by this test,
+                # which only exercises the length-validation branch.
+                return []
 
         pattern = Pattern()
         with pytest.raises(RuntimeError):

--- a/tests/quantization/test_annotation_utils.py
+++ b/tests/quantization/test_annotation_utils.py
@@ -11,7 +11,9 @@ import torch.nn as nn
 import torch.nn.functional as F
 from torch._ops import OpOverloadPacket
 
-from coreai_opt.quantization._graph._annotation_utils import _PASSTHROUGH_OP_OVERLOADS
+from coreai_opt.quantization._graph._qspec_constraint_generation import (
+    _PASSTHROUGH_OP_OVERLOADS,
+)
 
 
 def _overloadpackets_in_graph(model: nn.Module, example_inputs: tuple) -> set[OpOverloadPacket]:

--- a/tests/quantization/test_eager_quant.py
+++ b/tests/quantization/test_eager_quant.py
@@ -2011,7 +2011,12 @@ def test_warn_on_nonquantizable_tensor(caplog, config, warning_msg):
 
     quantizer = Quantizer(model, config)
     _ = quantizer.prepare(example_input)
-    if "*" in config.global_config.op_input_spec or "*" in config.global_config.op_state_spec:
+    # A wildcard *spec* sweeping up the int tensor stays silent. A wildcard
+    # holding None is an opt-out, not a spec, so it does not suppress the warning.
+    if (
+        config.global_config.op_input_spec.get("*") is not None
+        or config.global_config.op_state_spec.get("*") is not None
+    ):
         assert len(caplog.records) == 0
     else:
         assert len(caplog.records) == 1

--- a/tests/quantization/test_graph_mode_quantizer.py
+++ b/tests/quantization/test_graph_mode_quantizer.py
@@ -751,9 +751,7 @@ class TestInPlaceActivationPatternCoverage:
     _INPUT = (torch.randn(2, 4, 8, 8),)
 
     def _prepare(self, model: nn.Module):
-        return Quantizer(model.eval(), self._w8a8_config()).prepare(
-            example_inputs=self._INPUT
-        )
+        return Quantizer(model.eval(), self._w8a8_config()).prepare(example_inputs=self._INPUT)
 
     @staticmethod
     def _fake_quant_consumers(prepared) -> dict[str, int]:
@@ -832,18 +830,13 @@ class TestCatOfSigmoidReconciliation:
 
     @staticmethod
     def _by_target(model: torch.fx.GraphModule, needle: str) -> list[torch.fx.Node]:
-        return [
-            n for n in model.graph.nodes
-            if n.op == "call_function" and needle in str(n.target)
-        ]
+        return [n for n in model.graph.nodes if n.op == "call_function" and needle in str(n.target)]
 
     @staticmethod
     def _annotation(node: torch.fx.Node):
         return node.meta.get(Q_ANNOTATION_KEY)
 
-    def test_cat_of_sigmoid_shared_observer_topology(
-        self, weight_input_act_output_act_config
-    ):
+    def test_cat_of_sigmoid_shared_observer_topology(self, weight_input_act_output_act_config):
         """Every branch in the cat group should end up pointing at one anchor.
 
         Load-bearing invariants:
@@ -873,9 +866,7 @@ class TestCatOfSigmoidReconciliation:
         model = self._CatOfSigmoid().eval()
         example_inputs = (torch.randn(1, 3, 8, 8),)
 
-        prepared = Quantizer(model, weight_input_act_output_act_config).prepare(
-            example_inputs
-        )
+        prepared = Quantizer(model, weight_input_act_output_act_config).prepare(example_inputs)
 
         convs = self._by_target(prepared, "conv2d")
         sigmoids = self._by_target(prepared, "sigmoid")
@@ -900,8 +891,7 @@ class TestCatOfSigmoidReconciliation:
             "qparams_calculator"
         ]()
         assert anchor_calculator.qscheme == QuantizationScheme.ASYMMETRIC, (
-            f"reconciled qscheme did not reach the calculator: "
-            f"got {anchor_calculator.qscheme}"
+            f"reconciled qscheme did not reach the calculator: got {anchor_calculator.qscheme}"
         )
 
         # The two convs feeding the sigmoid pattern get no output_qspec:

--- a/tests/quantization/test_graph_mode_quantizer.py
+++ b/tests/quantization/test_graph_mode_quantizer.py
@@ -16,6 +16,11 @@ import torch
 import torch.nn as nn
 from torch.export.dynamic_shapes import Dim
 from torch.ops import coreai
+from torchao.quantization.pt2e.quantizer import (
+    QuantizationSpec as TorchAOQuantizationSpec,
+    SharedQuantizationSpec,
+)
+from torchao.quantization.pt2e.quantizer.quantizer import Q_ANNOTATION_KEY
 
 from coreai_opt import ExportBackend
 from coreai_opt._utils.metadata_utils import (
@@ -39,6 +44,7 @@ from coreai_opt.quantization._graph._prepare_for_export import (
 from coreai_opt.quantization._graph.quantizer import _AnnotationHandler
 from coreai_opt.quantization.spec import (
     PerBlockGranularity,
+    PerChannelGranularity,
     PerTensorGranularity,
     QuantizationScheme,
     default_activation_quantization_spec,
@@ -678,6 +684,261 @@ class TestAnnotationHandler:
             f"Expected annotate_single_pattern to be called {NUM_PATTERNS} times, but "
             f"was called {temp_pattern.match_single_pattern_call_count} times"
         )
+
+
+class TestInPlaceActivationPatternCoverage:
+    """An in-place activation must not fragment its conv-bn-relu pattern group.
+
+    ResNet50 is the motivating shape: ReLU is in-place throughout, and
+    ``prepare_qat_pt2e`` reparameterizes conv-bn rather than folding it, so a
+    fragmented group puts observers on ``conv2d -> div`` and ``batch_norm ->
+    relu_``. On a W8A8 benchmark that was 66 extra activation fake-quants, 0.22 pp
+    top-1 and ~13% eval time.
+    """
+
+    @staticmethod
+    def _w8a8_config() -> QuantizerConfig:
+        """Per-tensor int8 activations, per-channel int8 weights."""
+        act = QuantizationSpec(
+            dtype=torch.int8,
+            qscheme=QuantizationScheme.SYMMETRIC,
+            granularity=PerTensorGranularity(),
+        )
+        weight = QuantizationSpec(
+            dtype=torch.int8,
+            qscheme=QuantizationScheme.SYMMETRIC,
+            granularity=PerChannelGranularity(axis=0),
+        )
+        return QuantizerConfig(
+            global_config=ModuleQuantizerConfig(
+                op_input_spec={"*": act},
+                op_output_spec={"*": act},
+                op_state_spec={"weight": weight},
+            )
+        ).set_execution_mode("graph")
+
+    class _ConvBnRelu(nn.Module):
+        """The minimal unit: conv -> bn -> relu, in-place or not."""
+
+        def __init__(self, inplace: bool) -> None:
+            super().__init__()
+            self.conv = nn.Conv2d(4, 4, 1, bias=False)
+            self.bn = nn.BatchNorm2d(4)
+            self.relu = nn.ReLU(inplace=inplace)
+
+        def forward(self, x: torch.Tensor) -> torch.Tensor:
+            return self.relu(self.bn(self.conv(x)))
+
+    class _Bottleneck(nn.Module):
+        """ResNet50 bottleneck: two conv-bn-relu_, then conv-bn, add, relu_."""
+
+        def __init__(self) -> None:
+            super().__init__()
+            self.conv1 = nn.Conv2d(4, 4, 1, bias=False)
+            self.bn1 = nn.BatchNorm2d(4)
+            self.conv2 = nn.Conv2d(4, 4, 3, padding=1, bias=False)
+            self.bn2 = nn.BatchNorm2d(4)
+            self.conv3 = nn.Conv2d(4, 4, 1, bias=False)
+            self.bn3 = nn.BatchNorm2d(4)
+            self.relu = nn.ReLU(inplace=True)
+
+        def forward(self, x: torch.Tensor) -> torch.Tensor:
+            out = self.relu(self.bn1(self.conv1(x)))
+            out = self.relu(self.bn2(self.conv2(out)))
+            out = self.bn3(self.conv3(out))
+            return self.relu(out + x)
+
+    _INPUT = (torch.randn(2, 4, 8, 8),)
+
+    def _prepare(self, model: nn.Module):
+        return Quantizer(model.eval(), self._w8a8_config()).prepare(
+            example_inputs=self._INPUT
+        )
+
+    @staticmethod
+    def _fake_quant_consumers(prepared) -> dict[str, int]:
+        """Count fake-quant modules by the op that consumes each one."""
+        fq_targets = {
+            name
+            for name, module in prepared.named_modules()
+            if isinstance(module, FakeQuantizeImplBase)
+        }
+        counts: dict[str, int] = {}
+        for node in prepared.graph.nodes:
+            if node.op != "call_module" or node.target not in fq_targets:
+                continue
+            for user in node.users:
+                key = str(user.target) if user.op == "call_function" else user.op
+                counts[key] = counts.get(key, 0) + 1
+        return counts
+
+    def test_inplace_relu_quantizes_same_as_out_of_place(self) -> None:
+        """The two models are numerically identical, so they must quantize alike."""
+        inplace = self._fake_quant_consumers(self._prepare(self._ConvBnRelu(True)))
+        out_of_place = self._fake_quant_consumers(self._prepare(self._ConvBnRelu(False)))
+
+        # Keyed by consumer op, which differs only in the relu variant itself.
+        assert inplace.pop("aten.relu_.default", 0) == 0
+        assert out_of_place.pop("aten.relu.default", 0) == 0
+        assert inplace == out_of_place
+
+    @pytest.mark.parametrize("inplace", [True, False])
+    def test_no_observer_on_pattern_internal_edges(self, inplace: bool) -> None:
+        """``conv2d -> div`` and ``bn -> relu`` are internal to the pattern.
+
+        ``div`` is a reparameterization artifact, not a quantizable pattern, so an
+        observer feeding it means the group fragmented.
+        """
+        consumers = self._fake_quant_consumers(self._prepare(self._ConvBnRelu(inplace)))
+        assert "aten.div.Tensor" not in consumers
+        assert "aten.relu_.default" not in consumers
+        assert "aten.relu.default" not in consumers
+
+    def test_bottleneck_observers_only_at_block_boundaries(self) -> None:
+        """A bottleneck quantizes its conv weights and the residual add, nothing else."""
+        consumers = self._fake_quant_consumers(self._prepare(self._Bottleneck()))
+
+        assert consumers.get("aten.conv2d.default") == 6  # 3 activations + 3 weights
+        assert consumers.get("aten.add.Tensor") == 2  # both residual-add inputs
+        assert "aten.div.Tensor" not in consumers
+        assert "aten.relu_.default" not in consumers
+
+
+class TestCatOfSigmoidReconciliation:
+    """End-to-end reconciliation on a YOLOX-shape cat-of-sigmoid model.
+
+    Exercises the full annotation pipeline (pattern match → reconcile →
+    resolve) on the pattern that motivated the reconciler: a ``cat`` group
+    whose branches disagree on qscheme (one plain conv branch wants
+    symmetric; two sigmoid branches want affine via op-intrinsic override).
+    The reconciler must lattice-join to affine, pick a topo-first anchor,
+    and give every other slot a SharedQuantizationSpec pointing at it.
+    """
+
+    class _CatOfSigmoid(nn.Module):
+        """``cat([reg_conv(x), sigmoid(obj_conv(x)), sigmoid(cls_conv(x))])``."""
+
+        def __init__(self) -> None:
+            super().__init__()
+            self.reg = nn.Conv2d(3, 4, kernel_size=1)
+            self.obj = nn.Conv2d(3, 1, kernel_size=1)
+            self.cls = nn.Conv2d(3, 8, kernel_size=1)
+
+        def forward(self, x: torch.Tensor) -> torch.Tensor:
+            r = self.reg(x)
+            o = torch.sigmoid(self.obj(x))
+            c = torch.sigmoid(self.cls(x))
+            return torch.cat([r, o, c], dim=1)
+
+    @staticmethod
+    def _by_target(model: torch.fx.GraphModule, needle: str) -> list[torch.fx.Node]:
+        return [
+            n for n in model.graph.nodes
+            if n.op == "call_function" and needle in str(n.target)
+        ]
+
+    @staticmethod
+    def _annotation(node: torch.fx.Node):
+        return node.meta.get(Q_ANNOTATION_KEY)
+
+    def test_cat_of_sigmoid_shared_observer_topology(
+        self, weight_input_act_output_act_config
+    ):
+        """Every branch in the cat group should end up pointing at one anchor.
+
+        Load-bearing invariants:
+
+        - ``conv2d`` (the ``reg`` branch — topologically first covered node
+          in the cat group) carries the concrete ``QuantizationSpec``.
+        - Its qscheme is ``ASYMMETRIC``, not symmetric — the two sigmoid
+          branches propose asymmetric at ``OP_INTRINSIC_PRIORITY``, which
+          outranks the conv branch's user-config symmetric.
+
+          Asserted on the **qparams calculator**, not on
+          ``QuantizationSpec.qscheme``. ``_convert_to_pt2e_spec``
+          deliberately leaves the torchao-level ``qscheme`` unset, because
+          only the qscheme inside the observer's calculator is read
+          downstream. Checking the calculator is what proves the reconciled
+          value actually reaches runtime — the gap that motivated making the
+          reconciled fields, rather than a pre-built observer partial, the
+          source of truth.
+        - ``sigmoid``, ``sigmoid_1``, and ``cat`` all have
+          ``output_qspec = SharedQuantizationSpec(edge_or_node=conv2d)``.
+        - The cat's three input slots also share on ``conv2d``.
+        - ``conv2d_1`` / ``conv2d_2`` (the two convs feeding the sigmoids
+          inside the pattern group) have no ``output_qspec`` — the
+          internal-edge slot is intentionally left unannotated so torchao
+          doesn't insert a second observer between them and their sigmoid.
+        """
+        model = self._CatOfSigmoid().eval()
+        example_inputs = (torch.randn(1, 3, 8, 8),)
+
+        prepared = Quantizer(model, weight_input_act_output_act_config).prepare(
+            example_inputs
+        )
+
+        convs = self._by_target(prepared, "conv2d")
+        sigmoids = self._by_target(prepared, "sigmoid")
+        cats = self._by_target(prepared, "cat")
+
+        assert [n.name for n in convs] == ["conv2d", "conv2d_1", "conv2d_2"]
+        assert [n.name for n in sigmoids] == ["sigmoid", "sigmoid_1"]
+        assert [n.name for n in cats] == ["cat"]
+
+        anchor, internal_conv_1, internal_conv_2 = convs
+        sigmoid_a, sigmoid_b = sigmoids
+        (cat_node,) = cats
+
+        # Anchor carries a concrete spec, lattice-joined to affine.
+        anchor_ann = self._annotation(anchor)
+        assert anchor_ann is not None and anchor_ann._annotated
+        assert isinstance(anchor_ann.output_qspec, TorchAOQuantizationSpec)
+        assert anchor_ann.output_qspec.dtype == torch.int8
+        # The reconciled qscheme has to land where it is actually read: inside
+        # the observer's qparams calculator.
+        anchor_calculator = anchor_ann.output_qspec.observer_or_fake_quant_ctr.callable_args[
+            "qparams_calculator"
+        ]()
+        assert anchor_calculator.qscheme == QuantizationScheme.ASYMMETRIC, (
+            f"reconciled qscheme did not reach the calculator: "
+            f"got {anchor_calculator.qscheme}"
+        )
+
+        # The two convs feeding the sigmoid pattern get no output_qspec:
+        # the sigmoid is annotated on the shared side and the intermediate
+        # edge is pattern-internal.
+        for internal in (internal_conv_1, internal_conv_2):
+            internal_ann = self._annotation(internal)
+            assert internal_ann is not None
+            assert internal_ann.output_qspec is None, (
+                f"{internal.name} is a pattern-internal producer feeding "
+                f"sigmoid; its output slot must not be annotated."
+            )
+
+        # Every other slot in the group shares on the anchor.
+        for sharer in (sigmoid_a, sigmoid_b, cat_node):
+            sharer_ann = self._annotation(sharer)
+            assert sharer_ann is not None and sharer_ann._annotated
+            assert isinstance(sharer_ann.output_qspec, SharedQuantizationSpec)
+            assert sharer_ann.output_qspec.edge_or_node is anchor, (
+                f"{sharer.name}.output_qspec should share on {anchor.name}, "
+                f"got {sharer_ann.output_qspec.edge_or_node}"
+            )
+
+        # cat's three inputs share on the anchor too.
+        cat_ann = self._annotation(cat_node)
+        cat_input_producers = list(cat_ann.input_qspec_map.keys())
+        assert cat_input_producers == [anchor, sigmoid_a, sigmoid_b]
+        for producer, input_spec in cat_ann.input_qspec_map.items():
+            assert isinstance(input_spec, SharedQuantizationSpec), (
+                f"cat.input[{producer.name}] should be a SharedQuantizationSpec, "
+                f"got {type(input_spec).__name__}"
+            )
+            assert input_spec.edge_or_node is anchor
+
+        # Sanity: model still runs forward after annotation.
+        out = prepared(*example_inputs)
+        assert out.shape == (1, 4 + 1 + 8, 8, 8)
 
 
 class TestAPIOrdering:
@@ -1552,7 +1813,9 @@ class TestFixedQParamsActivations:
         assert fq.qscheme == expected_qscheme
         assert fq.qparams_calculator.qscheme == expected_qscheme
         assert fq.qscheme == fq.qparams_calculator.qscheme
-        assert fq.qparams_calculator.float_range == expected_float_range
+        # float_range is a list once it round-trips through QuantizationSpec;
+        # compare values, not container type.
+        assert tuple(fq.qparams_calculator.float_range) == tuple(expected_float_range)
         scale, _, _ = fq.calculate_qparams()
         torch.testing.assert_close(scale, torch.full_like(scale, expected_scale))
 
@@ -1677,7 +1940,7 @@ class TestFixedQParamsActivations:
         assert fq.qscheme == QuantizationScheme.ASYMMETRIC
         assert fq.qparams_calculator.qscheme == QuantizationScheme.ASYMMETRIC
         assert fq.qscheme == fq.qparams_calculator.qscheme
-        assert fq.qparams_calculator.float_range == (0.0, None)
+        assert tuple(fq.qparams_calculator.float_range) == (0.0, None)
 
         # Min is pinned to 0 — zero_point should stay at -128 across all phases.
         _, zp, _ = fq.calculate_qparams()
@@ -1704,8 +1967,26 @@ class TestFixedQParamsActivations:
         assert torch.all(zp == -128)
 
     def test_relu_qparams_propagated_through_passthrough_ops(self):
-        """Relu's ASYMMETRIC qscheme and pinned-min float_range propagate through
-        passthrough ops (view, squeeze, unsqueeze) to the following quantizable op's input FQ."""
+        """Relu's ASYMMETRIC qscheme and pinned-min float_range reach the
+        following quantizable op's input FQ, across ``view``, ``squeeze`` and
+        ``unsqueeze``.
+
+        Two FQ modules carry the relu-derived qparams — relu's own output and
+        ``linear2``'s input — not one. That is deliberate, not a missed
+        deduplication: these ops change tensor rank, and a single
+        ``QParamsCalculator`` cannot span a rank change (it caches
+        ``_resolved_axis`` on first use and sizes its running buffers to the
+        first tensor it sees; ``QParamsCalculatorBase._resolve_axis`` states the
+        invariant directly). So the two ends keep separate, correctly-shaped
+        observers and the reconciler copies the *facts* between them via
+        ``InheritFields``.
+
+        Those facts are safe to copy precisely because a passthrough changes no
+        values: the tensor at ``linear2``'s input is the same tensor relu
+        produced, so relu's proven range still holds. Contrast
+        ``cat([relu(a), b])``, where one observer covers two *different*
+        tensors and relu's pin is correctly relaxed to cover ``b``.
+        """
 
         class LinearReluPassthroughLinear(nn.Module):
             def __init__(self):
@@ -1728,18 +2009,17 @@ class TestFixedQParamsActivations:
         prepared_model = quantizer.prepare((example_input,))
         prepared_model(example_input)
 
-        # Both relu's output FQ and linear2's input FQ (reached through the passthrough chain)
-        # should carry the relu-adjusted spec.
         fqs_with_relu_range = [
             (name, m)
             for name, m in prepared_model.named_modules()
             if isinstance(m, FakeQuantizeImplBase)
-            and getattr(m.qparams_calculator, "float_range", None) == (0.0, None)
+            and tuple(getattr(m.qparams_calculator, "float_range", ()) or ()) == (0.0, None)
         ]
         assert len(fqs_with_relu_range) == 2, (
-            f"Expected 2 FQ modules with float_range=(0.0, None) "
-            f"(relu output + linear2 input via passthrough propagation), "
-            f"got {len(fqs_with_relu_range)}: {[n for n, _ in fqs_with_relu_range]}"
+            f"Expected 2 FQ modules with float_range=(0.0, None) — relu's own "
+            f"output plus linear2's input, reached through the "
+            f"view/squeeze/unsqueeze chain. Got {len(fqs_with_relu_range)}: "
+            f"{[n for n, _ in fqs_with_relu_range]}"
         )
         for name, fq in fqs_with_relu_range:
             assert fq.qscheme == QuantizationScheme.ASYMMETRIC, (

--- a/tests/quantization/test_qspec_reconcile.py
+++ b/tests/quantization/test_qspec_reconcile.py
@@ -1,0 +1,894 @@
+# Copyright 2026 Apple Inc.
+#
+# Use of this source code is governed by a BSD-3-Clause license that can
+# be found in the LICENSE file or at https://opensource.org/licenses/BSD-3-Clause
+
+"""Unit tests for the constraint-queue qspec reconciliation pipeline.
+
+Tests here are pure — they construct :class:`ProvisionalQSpec`
+:class:`ProvisionalQSpecMap` values and :class:`Constraint`s by hand and
+exercise ``.apply()`` directly. No fx graph construction. End-to-end
+pipeline behavior is covered by trace-driven checks against the
+walkthrough toy.
+"""
+
+from unittest.mock import Mock
+
+import pytest
+import torch
+
+from coreai_opt.config.spec import CompressionTargetTensor
+from coreai_opt.quantization._graph._annotation_pattern_registry import (
+    ConcatPattern,
+    _same_axis,
+)
+from coreai_opt.quantization._graph._qspec_constraints import (
+    InheritFields,
+    ShareFields,
+    ShareObserverInstance,
+    _reconcile_field,
+)
+from coreai_opt.quantization._graph._qspec_resolution import _build_concrete_spec
+from coreai_opt.quantization._graph._qspec_types import (
+    OP_INTRINSIC_PRIORITY,
+    FieldName,
+    FieldValue,
+    NodeSlot,
+    ProvisionalQSpec,
+    ProvisionalQSpecMap,
+    ReconciliationError,
+    SlotKind,
+)
+from coreai_opt.quantization.spec import (
+    PerChannelGranularity,
+    PerTensorGranularity,
+    QuantizationFormulation,
+    QuantizationScheme,
+)
+from coreai_opt.quantization.spec.fake_quantize import _DefaultFakeQuantizeImpl
+from coreai_opt.quantization.spec.qparams_calculator import (
+    MovingAverageQParamsCalculator,
+    StaticQParamsCalculator,
+    _DefaultQParamsCalculator,
+)
+from coreai_opt.quantization.spec.range_calculator import MinMaxRangeCalculator
+
+# ---------------------------------------------------------------------------
+# Test helpers.
+# ---------------------------------------------------------------------------
+
+
+def _slot(name: str = "s", kind: SlotKind = SlotKind.OUTPUT, arg_index: int = 0) -> NodeSlot:
+    """Opaque ``NodeSlot`` — reconciler never inspects the fx node."""
+    return NodeSlot(node=Mock(name=name), kind=kind, arg_index=arg_index)
+
+
+def _pspec(**fields: FieldValue) -> ProvisionalQSpec:
+    """Build a ProvisionalQSpec by keyword: DTYPE=FieldValue(int8, 0), ..."""
+    field_map = {FieldName[key]: value for key, value in fields.items()}
+    return ProvisionalQSpec(fields=field_map)
+
+
+def _fv(value, priority: int = 0) -> FieldValue:
+    return FieldValue(value=value, priority=priority)
+
+
+# ---------------------------------------------------------------------------
+# _reconcile_field policies.
+# ---------------------------------------------------------------------------
+
+
+class TestReconcileField:
+    def test_dtype_priority_wins(self) -> None:
+        a, b = _slot("a"), _slot("b")
+        state: ProvisionalQSpecMap = {
+            a: _pspec(DTYPE=_fv(torch.int4, priority=1)),
+            b: _pspec(DTYPE=_fv(torch.int8, priority=5)),
+        }
+        result = _reconcile_field(FieldName.DTYPE, frozenset({a, b}), state)
+        assert result.value == torch.int4  # priority 1 beats 5
+        assert result.priority == 1
+
+    def test_dtype_tie_first_encountered(self) -> None:
+        a, b = _slot("a"), _slot("b")
+        state: ProvisionalQSpecMap = {
+            a: _pspec(DTYPE=_fv(torch.int8, priority=3)),
+            b: _pspec(DTYPE=_fv(torch.int4, priority=3)),
+        }
+        result = _reconcile_field(FieldName.DTYPE, frozenset({a, b}), state)
+        # min() with equal keys returns the first — encounter order
+        assert result.value in (torch.int8, torch.int4)
+
+    def test_qscheme_priority_wins_over_looser_scheme(self) -> None:
+        """Higher-priority symmetric beats lower-priority affine.
+
+        Regression guard for the priority-vs-lattice decision: an earlier
+        revision lattice-joined qschemes so affine ("looser") always won,
+        which silently overrode whichever config the user had ranked
+        higher. Config precedence now decides.
+        """
+        a, b = _slot("a"), _slot("b")
+        state: ProvisionalQSpecMap = {
+            a: _pspec(QSCHEME=_fv(torch.per_tensor_symmetric, priority=0)),
+            b: _pspec(QSCHEME=_fv(torch.per_tensor_affine, priority=5)),
+        }
+        result = _reconcile_field(FieldName.QSCHEME, frozenset({a, b}), state)
+        assert result.value == torch.per_tensor_symmetric  # priority 0 wins
+        assert result.priority == 0  # min of {0, 5}
+
+    def test_qscheme_priority_wins_reversed(self) -> None:
+        """Same pair, priorities swapped — now affine wins. The user's
+        ranking is what changes the answer, not the qscheme itself."""
+        a, b = _slot("a"), _slot("b")
+        state: ProvisionalQSpecMap = {
+            a: _pspec(QSCHEME=_fv(torch.per_tensor_symmetric, priority=5)),
+            b: _pspec(QSCHEME=_fv(torch.per_tensor_affine, priority=0)),
+        }
+        result = _reconcile_field(FieldName.QSCHEME, frozenset({a, b}), state)
+        assert result.value == torch.per_tensor_affine
+        assert result.priority == 0
+
+    def test_qscheme_op_intrinsic_priority_outranks_user_config(self) -> None:
+        """An op-intrinsic proposal at OP_INTRINSIC_PRIORITY beats any
+        user-config proposal, however highly the user ranked it. This is
+        what keeps the sigmoid-into-cat case resolving to affine now that
+        the lattice join is gone."""
+        conv_out, sigmoid_out = _slot("conv_out"), _slot("sigmoid_out")
+        state: ProvisionalQSpecMap = {
+            # Best possible user priority.
+            conv_out: _pspec(QSCHEME=_fv(torch.per_tensor_symmetric, priority=0)),
+            # Op semantics, not user preference.
+            sigmoid_out: _pspec(
+                QSCHEME=_fv(torch.per_tensor_affine, priority=OP_INTRINSIC_PRIORITY)
+            ),
+        }
+        result = _reconcile_field(
+            FieldName.QSCHEME, frozenset({conv_out, sigmoid_out}), state
+        )
+        assert result.value == torch.per_tensor_affine
+        assert result.priority == OP_INTRINSIC_PRIORITY
+
+    def test_qscheme_per_channel_no_longer_auto_widens(self) -> None:
+        """Mixed granularity resolves by priority, not by widening to
+        per-channel. The old lattice returned per_channel whenever any
+        member proposed it; that silently upgraded granularity for slots
+        that had no valid ch_axis."""
+        a, b = _slot("a"), _slot("b")
+        state: ProvisionalQSpecMap = {
+            a: _pspec(QSCHEME=_fv(torch.per_tensor_symmetric, priority=0)),
+            b: _pspec(QSCHEME=_fv(torch.per_channel_symmetric, priority=5)),
+        }
+        result = _reconcile_field(FieldName.QSCHEME, frozenset({a, b}), state)
+        assert result.value == torch.per_tensor_symmetric
+
+    def test_qscheme_none_proposals_ignored(self) -> None:
+        """A slot with no qscheme opinion doesn't get to win the field."""
+        a, b = _slot("a"), _slot("b")
+        state: ProvisionalQSpecMap = {
+            a: _pspec(QSCHEME=_fv(None, priority=0)),
+            b: _pspec(QSCHEME=_fv(torch.per_tensor_affine, priority=5)),
+        }
+        result = _reconcile_field(FieldName.QSCHEME, frozenset({a, b}), state)
+        assert result.value == torch.per_tensor_affine
+
+    def test_float_range_union_relaxes_a_pin_against_an_unpinned_member(self) -> None:
+        """A pinned range loses to an unpinned one, per bound.
+
+        A shared observer measures every member of its group, so its range has
+        to cover them all. Keeping sigmoid's ``[0, 1]`` pin when another member
+        is unbounded would clip that member's values.
+        """
+        a, b = _slot("a"), _slot("b")
+        state: ProvisionalQSpecMap = {
+            a: _pspec(FLOAT_RANGE=_fv([0.0, 1.0], priority=0)),
+            b: _pspec(FLOAT_RANGE=_fv([None, None], priority=5)),
+        }
+        result = _reconcile_field(FieldName.FLOAT_RANGE, frozenset({a, b}), state)
+        assert result.value == [None, None]
+
+    def test_float_range_union_ignores_priority(self) -> None:
+        """Same as above with priorities swapped — covering the data is a
+        correctness constraint, not a preference, so priority doesn't rescue
+        the pin."""
+        a, b = _slot("a"), _slot("b")
+        state: ProvisionalQSpecMap = {
+            a: _pspec(FLOAT_RANGE=_fv([0.0, 1.0], priority=5)),
+            b: _pspec(FLOAT_RANGE=_fv([None, None], priority=0)),
+        }
+        result = _reconcile_field(FieldName.FLOAT_RANGE, frozenset({a, b}), state)
+        assert result.value == [None, None]
+
+    def test_float_range_union_widens_two_concrete_pins(self) -> None:
+        """sigmoid [0,1] sharing with tanh [-1,1] widens to cover both."""
+        a, b = _slot("a"), _slot("b")
+        state: ProvisionalQSpecMap = {
+            a: _pspec(FLOAT_RANGE=_fv([0.0, 1.0], priority=0)),
+            b: _pspec(FLOAT_RANGE=_fv([-1.0, 1.0], priority=0)),
+        }
+        result = _reconcile_field(FieldName.FLOAT_RANGE, frozenset({a, b}), state)
+        assert result.value == [-1.0, 1.0]
+
+    def test_float_range_union_is_per_bound(self) -> None:
+        """relu's pinned min survives while the max stays data-driven."""
+        a, b = _slot("a"), _slot("b")
+        state: ProvisionalQSpecMap = {
+            a: _pspec(FLOAT_RANGE=_fv([0.0, None], priority=0)),
+            b: _pspec(FLOAT_RANGE=_fv([0.0, None], priority=5)),
+        }
+        result = _reconcile_field(FieldName.FLOAT_RANGE, frozenset({a, b}), state)
+        assert result.value == [0.0, None]
+
+    def test_granularity_priority_wins(self) -> None:
+        """Granularity carries the axis, so it resolves as one unit rather than
+        letting a separate axis field disagree with it."""
+        a, b = _slot("a"), _slot("b")
+        per_tensor = PerTensorGranularity()
+        per_channel = PerChannelGranularity(axis=0)
+        state: ProvisionalQSpecMap = {
+            a: _pspec(GRANULARITY=_fv(per_channel, priority=0)),
+            b: _pspec(GRANULARITY=_fv(per_tensor, priority=5)),
+        }
+        result = _reconcile_field(FieldName.GRANULARITY, frozenset({a, b}), state)
+        assert result.value is per_channel
+
+    def test_quantization_target_priority_wins(self) -> None:
+        """Weight and activation slots do share observers — a shared-observer op
+        fed by a state node ties them. The higher-priority config's target wins,
+        so the rebuilt observer stays coherent with its other fields."""
+        weight_slot = _slot("flatten_in", kind=SlotKind.INPUT)
+        act_slot = _slot("flatten_out", kind=SlotKind.OUTPUT)
+        state: ProvisionalQSpecMap = {
+            weight_slot: _pspec(
+                QUANTIZATION_TARGET=_fv(CompressionTargetTensor.WEIGHT, priority=0)
+            ),
+            act_slot: _pspec(
+                QUANTIZATION_TARGET=_fv(CompressionTargetTensor.ACTIVATION, priority=1)
+            ),
+        }
+        result = _reconcile_field(
+            FieldName.QUANTIZATION_TARGET, frozenset({weight_slot, act_slot}), state
+        )
+        assert result.value is CompressionTargetTensor.WEIGHT
+
+    def test_missing_field_returns_none(self) -> None:
+        a, b = _slot("a"), _slot("b")
+        state: ProvisionalQSpecMap = {a: _pspec(), b: _pspec()}
+        assert _reconcile_field(FieldName.DTYPE, frozenset({a, b}), state) is None
+
+
+# ---------------------------------------------------------------------------
+# ShareFields.
+# ---------------------------------------------------------------------------
+
+
+class TestShareFields:
+    def test_broadcasts_winner_to_all_slots(self) -> None:
+        a, b, c = _slot("a"), _slot("b"), _slot("c")
+        state: ProvisionalQSpecMap = {
+            a: _pspec(DTYPE=_fv(torch.int4, priority=0)),
+            b: _pspec(DTYPE=_fv(torch.int8, priority=5)),
+            c: _pspec(),  # no proposal
+        }
+        con = ShareFields(_slots=frozenset({a, b, c}), fields=frozenset({FieldName.DTYPE}))
+        changed = con.apply(state)
+        assert changed == {b, c}  # a already had int4; b and c gain it
+        assert state[a].fields[FieldName.DTYPE].value == torch.int4
+        assert state[b].fields[FieldName.DTYPE].value == torch.int4
+        assert state[c].fields[FieldName.DTYPE].value == torch.int4
+        # All at priority 0 after reconciliation.
+        assert state[a].fields[FieldName.DTYPE].priority == 0
+        assert state[b].fields[FieldName.DTYPE].priority == 0
+
+    def test_noop_when_already_reconciled(self) -> None:
+        a, b = _slot("a"), _slot("b")
+        state: ProvisionalQSpecMap = {
+            a: _pspec(DTYPE=_fv(torch.int8, priority=0)),
+            b: _pspec(DTYPE=_fv(torch.int8, priority=0)),
+        }
+        con = ShareFields(_slots=frozenset({a, b}), fields=frozenset({FieldName.DTYPE}))
+        assert con.apply(state) == set()
+
+    def test_multiple_fields(self) -> None:
+        a, b = _slot("a"), _slot("b")
+        state: ProvisionalQSpecMap = {
+            a: _pspec(
+                DTYPE=_fv(torch.int4, priority=0),
+                QSCHEME=_fv(torch.per_tensor_symmetric, priority=0),
+            ),
+            b: _pspec(
+                DTYPE=_fv(torch.int8, priority=5),
+                QSCHEME=_fv(torch.per_tensor_affine, priority=5),
+            ),
+        }
+        con = ShareFields(
+            _slots=frozenset({a, b}),
+            fields=frozenset({FieldName.DTYPE, FieldName.QSCHEME}),
+        )
+        con.apply(state)
+        # Both fields resolve to a's values — a is higher priority on both.
+        assert state[a].fields[FieldName.DTYPE].value == torch.int4
+        assert state[b].fields[FieldName.DTYPE].value == torch.int4
+        assert state[a].fields[FieldName.QSCHEME].value == torch.per_tensor_symmetric
+        assert state[b].fields[FieldName.QSCHEME].value == torch.per_tensor_symmetric
+
+
+# ---------------------------------------------------------------------------
+# ShareObserverInstance.
+# ---------------------------------------------------------------------------
+
+
+class TestShareObserverInstance:
+    def test_merges_two_slots_into_one_instance(self) -> None:
+        a, b = _slot("a"), _slot("b")
+        state: ProvisionalQSpecMap = {
+            a: _pspec(DTYPE=_fv(torch.int8, priority=0)),
+            b: _pspec(DTYPE=_fv(torch.int8, priority=0)),
+        }
+        assert state[a] is not state[b]
+        con = ShareObserverInstance(_slots=frozenset({a, b}))
+        con.apply(state)
+        assert state[a] is state[b]  # identity, not just value equality
+
+    def test_field_mutation_after_share_propagates(self) -> None:
+        a, b = _slot("a"), _slot("b")
+        state: ProvisionalQSpecMap = {a: _pspec(), b: _pspec()}
+        ShareObserverInstance(_slots=frozenset({a, b})).apply(state)
+        state[a].fields[FieldName.DTYPE] = _fv(torch.int8, 0)
+        # b's ProvisionalQSpec is the same object → sees the new field.
+        assert state[b].fields[FieldName.DTYPE].value == torch.int8
+
+    def test_transitive_merge_pulls_in_prior_sharers(self) -> None:
+        a, b, c = _slot("a"), _slot("b"), _slot("c")
+        state: ProvisionalQSpecMap = {a: _pspec(), b: _pspec(), c: _pspec()}
+        # First merge a and b.
+        ShareObserverInstance(_slots=frozenset({a, b})).apply(state)
+        assert state[a] is state[b]
+        # Now merge a with c — b should be pulled in transitively.
+        ShareObserverInstance(_slots=frozenset({a, c})).apply(state)
+        assert state[a] is state[b] is state[c]
+
+    def test_reconciles_fields_across_merged_group(self) -> None:
+        a, b = _slot("a"), _slot("b")
+        state: ProvisionalQSpecMap = {
+            a: _pspec(DTYPE=_fv(torch.int4, priority=0)),
+            b: _pspec(DTYPE=_fv(torch.int8, priority=5)),
+        }
+        ShareObserverInstance(_slots=frozenset({a, b})).apply(state)
+        assert state[a].fields[FieldName.DTYPE].value == torch.int4
+        assert state[b].fields[FieldName.DTYPE].value == torch.int4
+        assert state[a] is state[b]
+
+    def test_noop_when_already_shared_with_correct_fields(self) -> None:
+        a, b = _slot("a"), _slot("b")
+        shared = _pspec(DTYPE=_fv(torch.int8, priority=0))
+        state: ProvisionalQSpecMap = {a: shared, b: shared}
+        changed = ShareObserverInstance(_slots=frozenset({a, b})).apply(state)
+        assert changed == set()
+        assert state[a] is shared
+        assert state[b] is shared
+
+
+# ---------------------------------------------------------------------------
+# Convergence / no-op behavior.
+# ---------------------------------------------------------------------------
+
+
+class TestConvergence:
+    def test_repeated_share_fields_stabilizes(self) -> None:
+        a, b = _slot("a"), _slot("b")
+        state: ProvisionalQSpecMap = {
+            a: _pspec(DTYPE=_fv(torch.int4, priority=1)),
+            b: _pspec(DTYPE=_fv(torch.int8, priority=5)),
+        }
+        con = ShareFields(_slots=frozenset({a, b}), fields=frozenset({FieldName.DTYPE}))
+        first = con.apply(state)
+        assert first  # something changed
+        # Immediate re-apply is a no-op — proves the priority-inheritance
+        # rule prevents oscillation.
+        assert con.apply(state) == set()
+
+    def test_repeated_share_observer_stabilizes(self) -> None:
+        a, b = _slot("a"), _slot("b")
+        state: ProvisionalQSpecMap = {a: _pspec(), b: _pspec()}
+        con = ShareObserverInstance(_slots=frozenset({a, b}))
+        first = con.apply(state)
+        assert first
+        assert con.apply(state) == set()
+
+
+# ---------------------------------------------------------------------------
+# YOLOX-shape scenario reconciliation.
+# ---------------------------------------------------------------------------
+
+
+def test_yolox_scenario_end_to_end_reconciliation() -> None:
+    """cat-of-sigmoid: two sigmoid branches plus a symmetric conv branch, all
+    merged into one observer group.
+
+    The sigmoids carry ``OP_INTRINSIC_PRIORITY`` on QSCHEME and FLOAT_RANGE
+    (what ``_apply_op_intrinsic_override`` writes), so:
+
+    * QSCHEME resolves to ASYMMETRIC — the intrinsic outranks user config.
+    * FLOAT_RANGE relaxes to unbounded — the group also contains the conv
+      output, which is not confined to [0, 1], so keeping the pin would clip
+      it. This is the union policy overriding even the reserved priority,
+      because covering the data is a correctness constraint.
+    """
+    conv_out = _slot("conv_out")
+    sig_a_out = _slot("sig_a_out")
+    sig_b_out = _slot("sig_b_out")
+    cat_out = _slot("cat_out")
+
+    def _user_activation(**overrides):
+        base = dict(
+            DTYPE=_fv(torch.int8, priority=5),
+            QSCHEME=_fv(QuantizationScheme.SYMMETRIC, priority=5),
+            FLOAT_RANGE=_fv([None, None], priority=5),
+            GRANULARITY=_fv(PerTensorGranularity(), priority=5),
+            QUANTIZATION_TARGET=_fv(CompressionTargetTensor.ACTIVATION, priority=5),
+        )
+        base.update(overrides)
+        return _pspec(**base)  # _pspec maps str -> FieldName itself
+
+    state: ProvisionalQSpecMap = {
+        conv_out: _user_activation(),
+        # Op-intrinsic contributions land out-of-band on both fields.
+        sig_a_out: _user_activation(
+            QSCHEME=_fv(QuantizationScheme.ASYMMETRIC, priority=OP_INTRINSIC_PRIORITY),
+            FLOAT_RANGE=_fv([0.0, 1.0], priority=OP_INTRINSIC_PRIORITY),
+        ),
+        sig_b_out: _user_activation(
+            QSCHEME=_fv(QuantizationScheme.ASYMMETRIC, priority=OP_INTRINSIC_PRIORITY),
+            FLOAT_RANGE=_fv([0.0, 1.0], priority=OP_INTRINSIC_PRIORITY),
+        ),
+        cat_out: _user_activation(),
+    }
+    ShareObserverInstance(_slots=frozenset({conv_out, sig_a_out, sig_b_out, cat_out})).apply(state)
+
+    # All four share one ProvisionalQSpec now.
+    assert state[conv_out] is state[sig_a_out] is state[sig_b_out] is state[cat_out]
+    shared = state[conv_out].fields
+    assert shared[FieldName.QSCHEME].value is QuantizationScheme.ASYMMETRIC
+    assert shared[FieldName.DTYPE].value == torch.int8
+    # The sigmoid pin is relaxed so the shared observer still covers the conv.
+    assert shared[FieldName.FLOAT_RANGE].value == [None, None]
+
+
+def test_adjacent_edge_share_resolves_dtype_conflict_by_priority() -> None:
+    """test_op_level_precedence-shape: linear1.OUTPUT wants int4 at lower
+    priority; linear2.INPUT wants int8 at higher priority. Adjacent-edge
+    sharing merges them; priority resolves dtype to int8."""
+    linear1_out = _slot("linear1_out", kind=SlotKind.OUTPUT)
+    linear2_in = _slot("linear2_in", kind=SlotKind.INPUT)
+    state: ProvisionalQSpecMap = {
+        linear1_out: _pspec(
+            DTYPE=_fv(torch.int4, priority=5),
+            QSCHEME=_fv(QuantizationScheme.SYMMETRIC, priority=5),
+            GRANULARITY=_fv(PerTensorGranularity(), priority=5),
+            QUANTIZATION_TARGET=_fv(CompressionTargetTensor.ACTIVATION, priority=5),
+        ),
+        linear2_in: _pspec(
+            DTYPE=_fv(torch.int8, priority=0),
+            QSCHEME=_fv(QuantizationScheme.SYMMETRIC, priority=0),
+            GRANULARITY=_fv(PerTensorGranularity(), priority=0),
+            QUANTIZATION_TARGET=_fv(CompressionTargetTensor.ACTIVATION, priority=0),
+        ),
+    }
+    ShareObserverInstance(_slots=frozenset({linear1_out, linear2_in})).apply(state)
+    assert state[linear1_out] is state[linear2_in]
+    assert state[linear1_out].fields[FieldName.DTYPE].value == torch.int8
+
+
+def test_share_fields_dtype_only_leaves_other_fields_independent() -> None:
+    """``ShareFields`` agrees on the named fields without merging the
+    ProvisionalQSpec objects, so everything else stays per-slot."""
+    a_out = _slot("a_out")
+    b_out = _slot("b_out")
+    state: ProvisionalQSpecMap = {
+        a_out: _pspec(DTYPE=_fv(torch.int8, priority=0)),
+        b_out: _pspec(DTYPE=_fv(torch.int4, priority=5)),
+    }
+    ShareFields(_slots=frozenset({a_out, b_out}), fields=frozenset({FieldName.DTYPE})).apply(state)
+    assert state[a_out] is not state[b_out]
+    assert state[a_out].fields[FieldName.DTYPE].value == torch.int8
+    assert state[b_out].fields[FieldName.DTYPE].value == torch.int8
+
+
+class TestConcatSharingConstraints:
+    """``ConcatPattern.generate_qspec_sharing_constraints`` picks between tying the
+    inputs to one observer and merely agreeing on dtype."""
+
+    @staticmethod
+    def _cat_node(rank: int, dim: int, n_inputs: int = 2):
+        node = Mock()
+        node.args = (None, dim)
+        node.kwargs = {}
+        node.meta = {"val": Mock(shape=tuple(range(1, rank + 1)))}
+        node.all_input_nodes = [Mock() for _ in range(n_inputs)]
+        return node
+
+    def _state(self, node, granularity) -> ProvisionalQSpecMap:
+        return {
+            NodeSlot(node=node, kind=SlotKind.OUTPUT, arg_index=0): _pspec(
+                DTYPE=_fv(torch.int8, priority=0),
+                GRANULARITY=_fv(granularity, priority=0),
+            ),
+            NodeSlot(node=node, kind=SlotKind.INPUT, arg_index=0): _pspec(
+                DTYPE=_fv(torch.int8, priority=0)
+            ),
+        }
+
+    def test_per_channel_along_concat_axis_shares_dtype_only(self) -> None:
+        """Each input keeps its own scale, so they need only agree on dtype."""
+        node = self._cat_node(rank=4, dim=1)
+        state = self._state(node, PerChannelGranularity(axis=1))
+        constraints = ConcatPattern.generate_qspec_sharing_constraints(node, state)
+        assert len(constraints) == 1
+        assert isinstance(constraints[0], ShareFields)
+        assert constraints[0].fields == frozenset({FieldName.DTYPE})
+
+    def test_per_channel_along_other_axis_shares_observer(self) -> None:
+        node = self._cat_node(rank=4, dim=1)
+        state = self._state(node, PerChannelGranularity(axis=0))
+        constraints = ConcatPattern.generate_qspec_sharing_constraints(node, state)
+        assert [type(c) for c in constraints] == [ShareObserverInstance]
+
+    def test_per_tensor_shares_observer(self) -> None:
+        node = self._cat_node(rank=4, dim=1)
+        state = self._state(node, PerTensorGranularity())
+        constraints = ConcatPattern.generate_qspec_sharing_constraints(node, state)
+        assert [type(c) for c in constraints] == [ShareObserverInstance]
+
+    def test_no_populated_input_slot_emits_nothing(self) -> None:
+        node = self._cat_node(rank=4, dim=1)
+        assert ConcatPattern.generate_qspec_sharing_constraints(node, {}) == []
+
+
+# ---------------------------------------------------------------------------
+# Concat axis normalization.
+# ---------------------------------------------------------------------------
+
+
+class TestConcatAxisNormalization:
+    """``_same_axis`` must treat negative and positive axis indices that name
+    the same dimension as equal.
+
+    ``torch.cat(..., dim=-3)`` survives ``torch.export`` as ``-3`` rather than
+    being normalized, while a spec's ``ch_axis`` is stored verbatim from the
+    user's config. Comparing them as raw integers made
+    ``per_channel_along_concat_axis`` wrongly ``False``, which forces every
+    concat input onto one observer even though per-channel-along-concat
+    semantics require each input to keep its own scale.
+    """
+
+    @staticmethod
+    def _node_with_rank(rank: int):
+        node = Mock()
+        node.meta = {"val": Mock(shape=tuple(range(1, rank + 1)))}
+        return node
+
+    @pytest.mark.parametrize(
+        "ch_axis, concat_dim, rank, expected",
+        [
+            (1, 1, 4, True),  # both positive, same dim
+            (1, -3, 4, True),  # positive vs negative, same dim (NCHW channel)
+            (-3, 1, 4, True),  # reversed
+            (-3, -3, 4, True),  # both negative, same dim
+            (0, -1, 4, False),  # genuinely different dims
+            (1, 2, 4, False),  # genuinely different dims
+            (0, -4, 4, True),  # batch dim via either sign
+        ],
+    )
+    def test_same_axis(self, ch_axis, concat_dim, rank, expected) -> None:
+        assert (
+            _same_axis(ch_axis, concat_dim, self._node_with_rank(rank)) is expected
+        )
+
+    def test_same_axis_without_metadata_falls_back_to_raw_compare(self) -> None:
+        """No ``val`` metadata means rank is unknown, so only an exact match
+        counts. Better a missed match than a crash mid-annotation."""
+        node = Mock()
+        node.meta = {}
+        assert _same_axis(1, 1, node) is True
+        assert _same_axis(1, -3, node) is False
+
+
+# ---------------------------------------------------------------------------
+# Field map -> observer round trip.
+# ---------------------------------------------------------------------------
+
+
+class TestBuildConcreteSpec:
+    """``_build_concrete_spec`` must carry every reconciled field into the
+    observer it builds.
+
+    This is the property the field/partial inversion exists to guarantee. In
+    the previous design the observer partial was reconciled as one opaque
+    field, so a reconciled ``QSCHEME`` was written to
+    ``TorchAOQuantizationSpec.qscheme`` — which nothing downstream reads —
+    while the qscheme that actually took effect stayed baked inside the
+    partial's qparams calculator, untouched by reconciliation.
+    """
+
+    @staticmethod
+    def _fields(**overrides):
+        base = {
+            FieldName.DTYPE: _fv(torch.int8),
+            FieldName.QSCHEME: _fv(QuantizationScheme.SYMMETRIC),
+            FieldName.QFORMULATION: _fv(QuantizationFormulation.ZP),
+            FieldName.GRANULARITY: _fv(PerTensorGranularity()),
+            FieldName.FLOAT_RANGE: _fv([None, None]),
+            FieldName.FAKE_QUANTIZE_CLS: _fv(_DefaultFakeQuantizeImpl),
+            FieldName.QPARAM_CALCULATOR_CLS: _fv(MovingAverageQParamsCalculator),
+            FieldName.RANGE_CALCULATOR_CLS: _fv(MinMaxRangeCalculator),
+            FieldName.SCALE_DTYPE: _fv(None),
+            FieldName.QUANTIZATION_TARGET: _fv(CompressionTargetTensor.ACTIVATION),
+        }
+        # Keyword keys arrive as strings; map them onto FieldName so they
+        # replace entries rather than adding new string-keyed ones.
+        base.update({FieldName[key]: value for key, value in overrides.items()})
+        return ProvisionalQSpec(fields=base)
+
+    @staticmethod
+    def _calculator(torchao_spec):
+        return torchao_spec.observer_or_fake_quant_ctr.callable_args["qparams_calculator"]()
+
+    def test_reconciled_qscheme_reaches_the_calculator(self) -> None:
+        """The regression guard for the original defect."""
+        spec = _build_concrete_spec(
+            self._fields(QSCHEME=_fv(QuantizationScheme.ASYMMETRIC))
+        )
+        assert self._calculator(spec).qscheme is QuantizationScheme.ASYMMETRIC
+
+    def test_reconciled_float_range_reaches_the_calculator(self) -> None:
+        spec = _build_concrete_spec(self._fields(FLOAT_RANGE=_fv([0.0, 1.0])))
+        assert tuple(self._calculator(spec).float_range) == (0.0, 1.0)
+
+    def test_reconciled_dtype_and_derived_range(self) -> None:
+        """quant_min/quant_max are not reconciled — they fall out of dtype and
+        qscheme when the spec is reassembled."""
+        spec = _build_concrete_spec(self._fields(DTYPE=_fv(torch.int8)))
+        assert spec.dtype == torch.int8
+        assert (spec.quant_min, spec.quant_max) == (-128, 127)
+
+    def test_target_selects_the_default_calculator(self) -> None:
+        """A ``"default"`` qparam calculator resolves via QUANTIZATION_TARGET:
+        Static for weights (derive once at prepare), MovingAverage for
+        activations (learn over calibration). This is why the target has to be
+        reconciled rather than guessed at resolution time."""
+        weight = _build_concrete_spec(
+            self._fields(
+                QPARAM_CALCULATOR_CLS=_fv(_DefaultQParamsCalculator),
+                QUANTIZATION_TARGET=_fv(CompressionTargetTensor.WEIGHT),
+            )
+        )
+        activation = _build_concrete_spec(
+            self._fields(
+                QPARAM_CALCULATOR_CLS=_fv(_DefaultQParamsCalculator),
+                QUANTIZATION_TARGET=_fv(CompressionTargetTensor.ACTIVATION),
+            )
+        )
+        assert isinstance(self._calculator(weight), StaticQParamsCalculator)
+        assert isinstance(self._calculator(activation), MovingAverageQParamsCalculator)
+
+    def test_empty_field_map_is_not_observed(self) -> None:
+        assert _build_concrete_spec(ProvisionalQSpec(fields={})) is None
+
+    def test_partial_field_map_raises(self) -> None:
+        """A group carrying only some fields means a constraint invented fields
+        for a slot that was never seeded from a config — surface it instead of
+        filling in defaults."""
+        with pytest.raises(ReconciliationError, match="Cannot rebuild"):
+            _build_concrete_spec(
+                ProvisionalQSpec(fields={FieldName.DTYPE: _fv(torch.int8)})
+            )
+
+
+# ---------------------------------------------------------------------------
+# Explicitly-declined slots.
+# ---------------------------------------------------------------------------
+
+
+class TestDeclinedSlots:
+    """A declined slot is distinct from one nothing has spoken for.
+
+    Absence means "no opinion"; declined means a config that covers this slot
+    resolved no spec for it. Collapsing the two let a decline be silently
+    discarded, because absence cannot outrank anything.
+    """
+
+    @staticmethod
+    def _observed(priority: int = 0) -> ProvisionalQSpec:
+        return ProvisionalQSpec(
+            fields={
+                FieldName.DTYPE: _fv(torch.int8, priority),
+                FieldName.QSCHEME: _fv(QuantizationScheme.SYMMETRIC, priority),
+                FieldName.GRANULARITY: _fv(PerTensorGranularity(), priority),
+                FieldName.QUANTIZATION_TARGET: _fv(
+                    CompressionTargetTensor.ACTIVATION, priority
+                ),
+            }
+        )
+
+    @staticmethod
+    def _declined(priority: int = 0) -> ProvisionalQSpec:
+        return ProvisionalQSpec(declined_by=priority)
+
+    def test_declined_is_not_the_same_as_empty(self) -> None:
+        assert self._declined().declined is True
+        assert ProvisionalQSpec().declined is False
+
+    def test_an_observing_member_outranks_a_decline(self) -> None:
+        """A decline loses to any member that wants observation.
+
+        The members are one tensor, so excluding one reference to it while
+        another asks for quantization is not a coherent instruction. For
+        ``cat(A, declined_B, C)`` the cat is still observed.
+        """
+        a, b, c = _slot("a"), _slot("b"), _slot("c")
+        state: ProvisionalQSpecMap = {
+            a: self._observed(priority=0),
+            b: self._declined(priority=7),
+            c: self._observed(priority=0),
+        }
+        ShareObserverInstance(_slots=frozenset({a, b, c})).apply(state)
+        assert state[a] is state[b] is state[c]
+        assert state[a].declined is False
+
+    def test_decline_loses_regardless_of_priority(self) -> None:
+        """Priority does not rescue a decline: it loses even when it holds the
+        best priority and the observing peer the worst."""
+        observed, declined = _slot("observed"), _slot("declined")
+        state: ProvisionalQSpecMap = {
+            observed: self._observed(priority=99),  # worst
+            declined: self._declined(priority=0),   # best
+        }
+        ShareObserverInstance(_slots=frozenset({observed, declined})).apply(state)
+        assert state[observed].declined is False
+
+    def test_group_declined_only_when_every_member_declines(self) -> None:
+        """With nothing asking for observation, the decline stands."""
+        a, b = _slot("a"), _slot("b")
+        state: ProvisionalQSpecMap = {
+            a: self._declined(priority=3),
+            b: self._declined(priority=7),
+        }
+        ShareObserverInstance(_slots=frozenset({a, b})).apply(state)
+        assert state[a] is state[b]
+        assert state[a].declined is True
+        assert state[a].declined_by == 3
+
+    def test_group_without_declines_stays_observed(self) -> None:
+        a, b = _slot("a"), _slot("b")
+        state: ProvisionalQSpecMap = {a: self._observed(), b: self._observed()}
+        ShareObserverInstance(_slots=frozenset({a, b})).apply(state)
+        assert state[a].declined is False
+        assert state[a].fields[FieldName.DTYPE].value == torch.int8
+
+    def test_declined_group_emits_no_annotation(self) -> None:
+        """Resolution skips a declined group, which is what leaves the op in
+        float for torchao."""
+        declined = self._observed()
+        declined.declined_by = 3
+        assert _build_concrete_spec(declined) is None
+
+
+# ---------------------------------------------------------------------------
+# Same-tensor propagation.
+# ---------------------------------------------------------------------------
+
+
+class TestInheritFields:
+    """``InheritFields`` copies data facts one direction; it does not merge.
+
+    Its reason to exist: slots either side of a rank-changing passthrough
+    observe the *same tensor* but cannot share an observer instance, because a
+    ``QParamsCalculator`` is sized to the rank of the first tensor it sees. A
+    fact proven about the data upstream therefore has to be copied, not
+    reconciled — ``ShareFields`` would route it through
+    ``_policy_float_range_union``, which relaxes the very pin being carried.
+    """
+
+    @staticmethod
+    def _with(**overrides) -> ProvisionalQSpec:
+        base = {
+            FieldName.DTYPE: _fv(torch.int8),
+            FieldName.QSCHEME: _fv(QuantizationScheme.SYMMETRIC),
+            FieldName.FLOAT_RANGE: _fv([None, None]),
+        }
+        base.update({FieldName[key]: value for key, value in overrides.items()})
+        return ProvisionalQSpec(fields=base)
+
+    _FACTS = frozenset({FieldName.QSCHEME, FieldName.FLOAT_RANGE})
+
+    def test_copies_facts_downstream(self) -> None:
+        src, dst = _slot("relu_out"), _slot("linear_in", kind=SlotKind.INPUT)
+        state: ProvisionalQSpecMap = {
+            src: self._with(
+                QSCHEME=_fv(QuantizationScheme.ASYMMETRIC, OP_INTRINSIC_PRIORITY),
+                FLOAT_RANGE=_fv([0.0, None], OP_INTRINSIC_PRIORITY),
+            ),
+            dst: self._with(),
+        }
+        changed = InheritFields(
+            source=src, targets=frozenset({dst}), fields=self._FACTS
+        ).apply(state)
+        assert changed == {dst}
+        assert state[dst].fields[FieldName.QSCHEME].value is QuantizationScheme.ASYMMETRIC
+        assert state[dst].fields[FieldName.FLOAT_RANGE].value == [0.0, None]
+
+    def test_does_not_merge_objects(self) -> None:
+        """Unlike ShareObserverInstance — each side keeps its own observer, which
+        is the whole point when rank differs."""
+        src, dst = _slot("a"), _slot("b")
+        state: ProvisionalQSpecMap = {src: self._with(), dst: self._with()}
+        InheritFields(source=src, targets=frozenset({dst}), fields=self._FACTS).apply(state)
+        assert state[src] is not state[dst]
+
+    def test_leaves_untargeted_fields_alone(self) -> None:
+        """DTYPE is a user choice, not a fact about the data, so it must not be
+        copied — doing so would let a passthrough override a higher-priority
+        config's dtype."""
+        src, dst = _slot("a"), _slot("b")
+        state: ProvisionalQSpecMap = {
+            src: self._with(DTYPE=_fv(torch.int4)),
+            dst: self._with(DTYPE=_fv(torch.int8)),
+        }
+        InheritFields(source=src, targets=frozenset({dst}), fields=self._FACTS).apply(state)
+        assert state[dst].fields[FieldName.DTYPE].value == torch.int8
+
+    def test_inherits_the_relaxed_value_not_a_stale_pin(self) -> None:
+        """If the source's own group relaxed its range first, targets must get
+        the relaxed value. Guards against propagating a pin that reconciliation
+        already decided was unsafe."""
+        src, dst = _slot("a"), _slot("b")
+        state: ProvisionalQSpecMap = {
+            src: self._with(FLOAT_RANGE=_fv([None, None])),  # already relaxed
+            dst: self._with(FLOAT_RANGE=_fv([0.0, 1.0])),
+        }
+        InheritFields(source=src, targets=frozenset({dst}), fields=self._FACTS).apply(state)
+        assert state[dst].fields[FieldName.FLOAT_RANGE].value == [None, None]
+
+    def test_second_apply_is_a_noop(self) -> None:
+        """Convergence: this constraint copies at unchanged priority rather than
+        lowering one, so idempotence is what keeps the drain loop terminating."""
+        src, dst = _slot("a"), _slot("b")
+        state: ProvisionalQSpecMap = {
+            src: self._with(FLOAT_RANGE=_fv([0.0, None])),
+            dst: self._with(),
+        }
+        con = InheritFields(source=src, targets=frozenset({dst}), fields=self._FACTS)
+        assert con.apply(state)
+        assert con.apply(state) == set()
+
+    def test_skips_declined_target(self) -> None:
+        """A decline is an explicit opt-out and outranks a propagated fact."""
+        src, dst = _slot("a"), _slot("b")
+        state: ProvisionalQSpecMap = {
+            src: self._with(FLOAT_RANGE=_fv([0.0, None])),
+            dst: ProvisionalQSpec(declined_by=0),
+        }
+        assert InheritFields(
+            source=src, targets=frozenset({dst}), fields=self._FACTS
+        ).apply(state) == set()
+
+    def test_declined_source_carries_nothing(self) -> None:
+        src, dst = _slot("a"), _slot("b")
+        state: ProvisionalQSpecMap = {
+            src: ProvisionalQSpec(declined_by=0),
+            dst: self._with(),
+        }
+        assert InheritFields(
+            source=src, targets=frozenset({dst}), fields=self._FACTS
+        ).apply(state) == set()
+
+    def test_absent_target_is_not_created(self) -> None:
+        """Propagation must not invent observation for a slot nothing asked to
+        observe — that would produce a partial field map, which
+        ``_build_concrete_spec`` rejects."""
+        src, absent = _slot("a"), _slot("absent")
+        state: ProvisionalQSpecMap = {src: self._with(FLOAT_RANGE=_fv([0.0, None]))}
+        assert InheritFields(
+            source=src, targets=frozenset({absent}), fields=self._FACTS
+        ).apply(state) == set()
+        assert absent not in state

--- a/tests/quantization/test_qspec_reconcile.py
+++ b/tests/quantization/test_qspec_reconcile.py
@@ -142,9 +142,7 @@ class TestReconcileField:
                 QSCHEME=_fv(torch.per_tensor_affine, priority=OP_INTRINSIC_PRIORITY)
             ),
         }
-        result = _reconcile_field(
-            FieldName.QSCHEME, frozenset({conv_out, sigmoid_out}), state
-        )
+        result = _reconcile_field(FieldName.QSCHEME, frozenset({conv_out, sigmoid_out}), state)
         assert result.value == torch.per_tensor_affine
         assert result.priority == OP_INTRINSIC_PRIORITY
 
@@ -580,9 +578,7 @@ class TestConcatAxisNormalization:
         ],
     )
     def test_same_axis(self, ch_axis, concat_dim, rank, expected) -> None:
-        assert (
-            _same_axis(ch_axis, concat_dim, self._node_with_rank(rank)) is expected
-        )
+        assert _same_axis(ch_axis, concat_dim, self._node_with_rank(rank)) is expected
 
     def test_same_axis_without_metadata_falls_back_to_raw_compare(self) -> None:
         """No ``val`` metadata means rank is unknown, so only an exact match
@@ -635,9 +631,7 @@ class TestBuildConcreteSpec:
 
     def test_reconciled_qscheme_reaches_the_calculator(self) -> None:
         """The regression guard for the original defect."""
-        spec = _build_concrete_spec(
-            self._fields(QSCHEME=_fv(QuantizationScheme.ASYMMETRIC))
-        )
+        spec = _build_concrete_spec(self._fields(QSCHEME=_fv(QuantizationScheme.ASYMMETRIC)))
         assert self._calculator(spec).qscheme is QuantizationScheme.ASYMMETRIC
 
     def test_reconciled_float_range_reaches_the_calculator(self) -> None:
@@ -679,9 +673,7 @@ class TestBuildConcreteSpec:
         for a slot that was never seeded from a config — surface it instead of
         filling in defaults."""
         with pytest.raises(ReconciliationError, match="Cannot rebuild"):
-            _build_concrete_spec(
-                ProvisionalQSpec(fields={FieldName.DTYPE: _fv(torch.int8)})
-            )
+            _build_concrete_spec(ProvisionalQSpec(fields={FieldName.DTYPE: _fv(torch.int8)}))
 
 
 # ---------------------------------------------------------------------------
@@ -704,9 +696,7 @@ class TestDeclinedSlots:
                 FieldName.DTYPE: _fv(torch.int8, priority),
                 FieldName.QSCHEME: _fv(QuantizationScheme.SYMMETRIC, priority),
                 FieldName.GRANULARITY: _fv(PerTensorGranularity(), priority),
-                FieldName.QUANTIZATION_TARGET: _fv(
-                    CompressionTargetTensor.ACTIVATION, priority
-                ),
+                FieldName.QUANTIZATION_TARGET: _fv(CompressionTargetTensor.ACTIVATION, priority),
             }
         )
 
@@ -741,7 +731,7 @@ class TestDeclinedSlots:
         observed, declined = _slot("observed"), _slot("declined")
         state: ProvisionalQSpecMap = {
             observed: self._observed(priority=99),  # worst
-            declined: self._declined(priority=0),   # best
+            declined: self._declined(priority=0),  # best
         }
         ShareObserverInstance(_slots=frozenset({observed, declined})).apply(state)
         assert state[observed].declined is False
@@ -810,9 +800,9 @@ class TestInheritFields:
             ),
             dst: self._with(),
         }
-        changed = InheritFields(
-            source=src, targets=frozenset({dst}), fields=self._FACTS
-        ).apply(state)
+        changed = InheritFields(source=src, targets=frozenset({dst}), fields=self._FACTS).apply(
+            state
+        )
         assert changed == {dst}
         assert state[dst].fields[FieldName.QSCHEME].value is QuantizationScheme.ASYMMETRIC
         assert state[dst].fields[FieldName.FLOAT_RANGE].value == [0.0, None]
@@ -868,9 +858,10 @@ class TestInheritFields:
             src: self._with(FLOAT_RANGE=_fv([0.0, None])),
             dst: ProvisionalQSpec(declined_by=0),
         }
-        assert InheritFields(
-            source=src, targets=frozenset({dst}), fields=self._FACTS
-        ).apply(state) == set()
+        assert (
+            InheritFields(source=src, targets=frozenset({dst}), fields=self._FACTS).apply(state)
+            == set()
+        )
 
     def test_declined_source_carries_nothing(self) -> None:
         src, dst = _slot("a"), _slot("b")
@@ -878,9 +869,10 @@ class TestInheritFields:
             src: ProvisionalQSpec(declined_by=0),
             dst: self._with(),
         }
-        assert InheritFields(
-            source=src, targets=frozenset({dst}), fields=self._FACTS
-        ).apply(state) == set()
+        assert (
+            InheritFields(source=src, targets=frozenset({dst}), fields=self._FACTS).apply(state)
+            == set()
+        )
 
     def test_absent_target_is_not_created(self) -> None:
         """Propagation must not invent observation for a slot nothing asked to
@@ -888,7 +880,8 @@ class TestInheritFields:
         ``_build_concrete_spec`` rejects."""
         src, absent = _slot("a"), _slot("absent")
         state: ProvisionalQSpecMap = {src: self._with(FLOAT_RANGE=_fv([0.0, None]))}
-        assert InheritFields(
-            source=src, targets=frozenset({absent}), fields=self._FACTS
-        ).apply(state) == set()
+        assert (
+            InheritFields(source=src, targets=frozenset({absent}), fields=self._FACTS).apply(state)
+            == set()
+        )
         assert absent not in state

--- a/tests/quantization/test_quantization_config.py
+++ b/tests/quantization/test_quantization_config.py
@@ -10,7 +10,7 @@ import torch
 from pydantic import ValidationError
 
 import tests.utils as utils
-from coreai_opt._utils.config_utils import ALL_TENSORS as _ALL_TENSORS
+from coreai_opt._utils.config_utils import ALL_TENSORS as _ALL_TENSORS, spec_dict_is_active
 from coreai_opt.quantization import QuantizationSpec, Quantizer
 from coreai_opt.quantization.config.quantization_config import (
     _QUANTIZATION_CONFIG,
@@ -99,9 +99,13 @@ def test_init_module_quantizer_config():
     assert module_config.qat_schedule is None
 
 
-def test_init_module_quantizer_config_with_none_vs_empty_dict():
-    """Test that ModuleQuantizerConfig can take both None and {} for attributes"""
-    module_config_1 = ModuleQuantizerConfig(
+def test_init_module_quantizer_config_none_and_empty_dict_differ():
+    """``None`` disables an op-level category; ``{}`` expresses no opinion.
+
+    Module-level specs are unaffected — they keep normalizing None to ``{}``,
+    since only op-level specs feed per-tensor annotation decisions.
+    """
+    empty = ModuleQuantizerConfig(
         op_input_spec={},
         op_output_spec={},
         op_state_spec={},
@@ -109,7 +113,7 @@ def test_init_module_quantizer_config_with_none_vs_empty_dict():
         module_output_spec={},
         module_state_spec={},
     )
-    module_config_2 = ModuleQuantizerConfig(
+    disabled = ModuleQuantizerConfig(
         op_input_spec=None,
         op_output_spec=None,
         op_state_spec=None,
@@ -117,7 +121,14 @@ def test_init_module_quantizer_config_with_none_vs_empty_dict():
         module_output_spec=None,
         module_state_spec=None,
     )
-    assert module_config_1 == module_config_2
+    assert empty != disabled
+    assert empty.op_input_spec == {}
+    assert disabled.op_input_spec == {_ALL_TENSORS: None}
+    # Module-level specs stay empty either way.
+    assert empty.module_input_spec == disabled.module_input_spec == {}
+    # Neither asks for compression.
+    assert not spec_dict_is_active(empty.op_input_spec)
+    assert not spec_dict_is_active(disabled.op_input_spec)
 
 
 def test_init_op_quantizer_config():
@@ -128,19 +139,29 @@ def test_init_op_quantizer_config():
     assert op_config.op_state_spec["weight"] == default_weight_quantization_spec()
 
 
-def test_init_op_quantizer_config_with_none_vs_empty_dict():
-    """Test that OpQuantizerConfig can take both None and {} for attributes"""
-    op_config_1 = OpQuantizerConfig(
+def test_init_op_quantizer_config_none_and_empty_dict_differ():
+    """``None`` disables a category; ``{}`` expresses no opinion about it.
+
+    These were equivalent before, both normalizing to ``{}``. Keeping them
+    distinct is what lets a consumer tell "the user excluded this tensor" from
+    "no key addressed this tensor".
+    """
+    empty = OpQuantizerConfig(
         op_input_spec={},
         op_output_spec={},
         op_state_spec={},
     )
-    op_config_2 = OpQuantizerConfig(
+    disabled = OpQuantizerConfig(
         op_input_spec=None,
         op_output_spec=None,
         op_state_spec=None,
     )
-    assert op_config_1 == op_config_2
+    assert empty != disabled
+    assert empty.op_input_spec == {}
+    assert disabled.op_input_spec == {_ALL_TENSORS: None}
+    # Neither asks for compression.
+    assert not spec_dict_is_active(empty.op_input_spec)
+    assert not spec_dict_is_active(disabled.op_input_spec)
 
 
 def test_from_yaml(tmp_path, expanded_dtype_allowlist):  # noqa: F811

--- a/tests/test_compression_config.py
+++ b/tests/test_compression_config.py
@@ -11,7 +11,7 @@ import torch
 import torch.nn as nn
 from pydantic import ValidationError
 
-from coreai_opt._utils.config_utils import ConfigLevel
+from coreai_opt._utils.config_utils import ALL_TENSORS, ConfigLevel
 from coreai_opt.common import CompressionType
 from coreai_opt.config import (
     CompressionConfig,
@@ -84,13 +84,14 @@ def test_op_compression_config_defaults():
 
 
 def test_op_compression_config_explicit_none():
-    """Test that explicit None converts to empty dict."""
+    """Explicit None disables the category, as ``{"*": None}``."""
     config = OpFooCompressionConfig(op_input_spec=None, op_output_spec=None, op_state_spec=None)
 
-    # Explicit None should result in empty dicts (via BeforeValidator)
-    assert config.op_input_spec == {}
-    assert config.op_output_spec == {}
-    assert config.op_state_spec == {}
+    # None is shorthand for "compress no tensor here", kept at the tensor level so
+    # it stays distinguishable from {}, which names no tensor and says nothing.
+    assert config.op_input_spec == {ALL_TENSORS: None}
+    assert config.op_output_spec == {ALL_TENSORS: None}
+    assert config.op_state_spec == {ALL_TENSORS: None}
 
 
 def test_op_compression_config_with_specs():
@@ -186,10 +187,10 @@ def test_module_compression_config_explicit_none():
         module_state_spec=None,
     )
 
-    # All should be empty dicts
-    assert config.op_input_spec == {}
-    assert config.op_output_spec == {}
-    assert config.op_state_spec == {}
+    # Op-level specs disable at the tensor level; the rest are simply empty.
+    assert config.op_input_spec == {ALL_TENSORS: None}
+    assert config.op_output_spec == {ALL_TENSORS: None}
+    assert config.op_state_spec == {ALL_TENSORS: None}
     assert config.op_type_config == {}
     assert config.op_name_config == {}
     assert config.module_input_spec == {}
@@ -203,11 +204,11 @@ def test_module_compression_config_none_op_type_config():
         op_type_config={"linear": None, "conv": OpFooCompressionConfig()}
     )
 
-    # None should be normalized to an OpConfig with empty specs
+    # None should be normalized to an OpConfig with every category disabled
     assert isinstance(config.op_type_config["linear"], OpFooCompressionConfig)
-    assert config.op_type_config["linear"].op_input_spec == {}
-    assert config.op_type_config["linear"].op_output_spec == {}
-    assert config.op_type_config["linear"].op_state_spec == {}
+    assert config.op_type_config["linear"].op_input_spec == {ALL_TENSORS: None}
+    assert config.op_type_config["linear"].op_output_spec == {ALL_TENSORS: None}
+    assert config.op_type_config["linear"].op_state_spec == {ALL_TENSORS: None}
 
     # Non-None should be unchanged (has defaults)
     assert config.op_type_config["conv"].op_input_spec == {"*": DummySpec(value=1)}
@@ -219,11 +220,11 @@ def test_module_compression_config_none_op_name_config():
         op_name_config={"layer1.weight": None, "layer2.weight": OpFooCompressionConfig()}
     )
 
-    # None should be normalized to an OpConfig with empty specs
+    # None should be normalized to an OpConfig with every category disabled
     assert isinstance(config.op_name_config["layer1.weight"], OpFooCompressionConfig)
-    assert config.op_name_config["layer1.weight"].op_input_spec == {}
-    assert config.op_name_config["layer1.weight"].op_output_spec == {}
-    assert config.op_name_config["layer1.weight"].op_state_spec == {}
+    assert config.op_name_config["layer1.weight"].op_input_spec == {ALL_TENSORS: None}
+    assert config.op_name_config["layer1.weight"].op_output_spec == {ALL_TENSORS: None}
+    assert config.op_name_config["layer1.weight"].op_state_spec == {ALL_TENSORS: None}
 
     # Non-None should be unchanged (has defaults)
     assert config.op_name_config["layer2.weight"].op_input_spec == {"*": DummySpec(value=1)}

--- a/tests/test_quantization_preset.py
+++ b/tests/test_quantization_preset.py
@@ -16,6 +16,7 @@ import pytest
 import torch
 from torch import nn
 
+from coreai_opt._utils.config_utils import ALL_TENSORS
 from coreai_opt._utils.python_utils import fqn
 from coreai_opt.base_model_compressor import ExportBackend
 from coreai_opt.quantization import (
@@ -29,6 +30,7 @@ from coreai_opt.quantization.spec import (
     PerChannelGranularity,
     QuantizationScheme,
 )
+from coreai_opt.quantization.spec.fake_quantize import FakeQuantizeImplBase
 
 # Canonical fully-disabled override produced by only_for / without / set_global(None).
 DISABLED_MODULE_CONFIG = ModuleQuantizerConfig(
@@ -64,6 +66,25 @@ class _DemoModel(nn.Module):
         return self.head(self.detr_decoder(self.text_encoder(x)))
 
 
+class _BatchNormModel(nn.Module):
+    """Exercises conv-bn folding: conv-bn-relu, conv-bn, pool, flatten, linear."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.conv1 = nn.Conv2d(3, 8, 3, padding=1)
+        self.bn1 = nn.BatchNorm2d(8)
+        self.relu = nn.ReLU()
+        self.conv2 = nn.Conv2d(8, 8, 3, padding=1)
+        self.bn2 = nn.BatchNorm2d(8)
+        self.fc = nn.Linear(8, 4)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x = self.relu(self.bn1(self.conv1(x)))
+        x = self.bn2(self.conv2(x))
+        x = torch.flatten(nn.functional.adaptive_avg_pool2d(x, 1), 1)
+        return self.fc(x)
+
+
 # ---------------------------------------------------------------------------
 # Preset factories
 # ---------------------------------------------------------------------------
@@ -96,10 +117,10 @@ def test_preset_returns_correct_type(owner_cls, preset_name):
 @pytest.mark.parametrize("owner_cls", _OWNER_CLASSES)
 @pytest.mark.parametrize("preset_name", _PRESET_NAMES)
 def test_preset_is_weight_only(owner_cls, preset_name):
-    """All built-in presets are weight-only — empty input/output activation specs."""
+    """All built-in presets are weight-only — activations explicitly disabled."""
     module = _module_config(getattr(owner_cls.presets, preset_name)())
-    assert module.op_input_spec == {}
-    assert module.op_output_spec == {}
+    assert module.op_input_spec == {ALL_TENSORS: None}
+    assert module.op_output_spec == {ALL_TENSORS: None}
 
 
 @pytest.mark.parametrize("owner_cls", _OWNER_CLASSES)
@@ -130,6 +151,38 @@ def test_w4_per_block_block_size_override(owner_cls):
     config = owner_cls.presets.w4_per_block(block_size=64)
     weight_spec = _module_config(config).op_state_spec["weight"]
     assert weight_spec.granularity.block_size == 64
+
+
+# ``w4_per_block`` is omitted: this model's channel counts aren't divisible by
+# the default block size, so it quantizes nothing.
+@pytest.mark.parametrize("preset_name", ["w8", "w4"])
+def test_preset_does_not_quantize_batchnorm_affine_params(preset_name):
+    """A conv-bn pattern quantizes the folded conv weight, not the bn's affine scale.
+
+    The bn node is covered so that no observer lands on the internal conv->bn edge,
+    but a pattern's state spec belongs to the op it is anchored on. Quantizing
+    ``bn.weight`` also breaks the axis-default pass, since ``batch_norm`` has no
+    per-channel axis default to resolve ``axis=None`` against.
+    """
+    config = getattr(QuantizerConfig.presets, preset_name)()
+    prepared = Quantizer(_BatchNormModel().eval(), config).prepare(
+        example_inputs=(torch.randn(2, 3, 8, 8),)
+    )
+
+    fq_names = {
+        name
+        for name, module in prepared.named_modules()
+        if isinstance(module, FakeQuantizeImplBase)
+    }
+    # One per weight-bearing op: conv1, conv2, fc. Matches main_oss.
+    assert len(fq_names) == 3
+
+    for node in prepared.graph.nodes:
+        if node.op == "call_function" and node.name.startswith("batch_norm"):
+            weight_arg = node.all_input_nodes[1]
+            assert weight_arg.name not in fq_names, (
+                f"{node.name} weight {weight_arg.name} should not be fake-quantized"
+            )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
This PR changes the annotation propagation logic for graph mode to a constraint-based algorithm.

Previously, we encountered a bug on YOLO-style models, where the following pattern would lead to a crash:

```
x = concat(conv(...), sigmoid(...), ...)
```

This pointed to a root cause where sigmoid would use fixed qparams (since we know that it has a (0, 1) range), and conv would have a "floating" qspec.  Concat would force the two to have the same qspec, but this propagation was interleaved with iterating and applying the patterns we matched.  Conv would go first, then when sigmoid was applied it would crash, expecting to be a fixed qparams qspec instead of a shared qspec.

It's more robust to first identify which nodes will share qspecs with which other nodes, then generate actual torchao qspecs to fit those constraints.  This changes the annotation propagation algorithm to do that.  In this new approach, conv, concat, and sigmoid know about each other before deciding on their qspecs, and we can create a single floating qspec that applies to the whole group.

Then entry point here is `_qspec_reconcile.py`.  This is the driver for the new algorithm.  We use the same pattern matching as before to generate "provisional" qspecs, then explicitly construct a queue of constraints, applying them and reconciling the provisional qspecs as we go.  After that, we translate our provisional qspecs into actual qspecs, handing back flow to the existing annotator from there.

Tested on unit tests, both existing ones and new ones exercising the YOLO case which prompted this investigation.

Benchmarked on W8 and W8A8 Resnet50, getting identical accuracies pre- and post- rewrite.  This is expected, as Resnet50 should not get different fake quantizers after this change.

This also adds the "architecture notes" directory, with a high-level explanation of the new annotation propagation