### PR TITLE
fix(quantization): align shared-weight QAT schedule owner with dtype (graph mode)

### DIFF
--- a/changelog.d/41.fixed
+++ b/changelog.d/41.fixed
@@ -1,0 +1,1 @@
+Fix graph-mode `Quantizer` resolving a tied weight's QAT schedule from a different module than its dtype. A shared fake-quantize module's owning module is now picked by the same config priority that decides its `dtype`, instead of by graph order, so the schedule and dtype for a shared weight always come from one consistent module.

--- a/src/coreai_opt/quantization/_graph/quantizer.py
+++ b/src/coreai_opt/quantization/_graph/quantizer.py
@@ -203,6 +203,13 @@ class _AnnotationHandler(TorchPT2EQuantizer):
         self._module_name_to_state_names_map = module_name_to_state_names_map
         self._extra_patterns: list[type] = list(extra_patterns or [])
         self._kv_cache_quant_configs = kv_cache_quant_configs or {}
+        # Populated by annotate(): maps each annotated node to the priority
+        # (lower = higher precedence) its winning config carried during
+        # annotation ordering. Exposed via the _node_priorities property so
+        # GraphQuantizer can later resolve a shared FQ module's owning module
+        # using the same priority that decided its DTYPE field (see
+        # GraphQuantizer._get_fake_quantize_modules).
+        self._priority_by_node: dict[torch.fx.Node, int] = {}
 
         # Build reverse map: alias → canonical for O(1) lookup during node matching.
         self._alias_to_canonical: dict[str, str] = {
@@ -210,6 +217,16 @@ class _AnnotationHandler(TorchPT2EQuantizer):
             for canonical, aliases in canonical_to_aliases.items()
             for alias in aliases
         }
+
+    @property
+    def _node_priorities(self) -> dict[torch.fx.Node, int]:
+        """A copy of the node-priority map, safe for callers to hold onto.
+
+        Returning a copy rather than ``self._priority_by_node`` directly keeps
+        a caller's reference (e.g. ``GraphQuantizer``) from aliasing this
+        instance's internal, mutable state.
+        """
+        return dict(self._priority_by_node)
 
     def _all_patterns(self) -> list[type]:
         """Globally-registered patterns plus per-instance ``extra_patterns``."""
@@ -271,9 +288,11 @@ class _AnnotationHandler(TorchPT2EQuantizer):
         # so every covered node has (config, priority, pattern_group) for
         # its slots. Priority = position in the sorted list (lower = higher
         # priority); used by reconcile() to break dtype ties within a
-        # shared-observer group.
+        # shared-observer group. self._priority_by_node is populated here
+        # directly (rather than via a local dict copied in afterward) so it's
+        # always in sync with what this annotate() call actually decided.
         winning_configs: dict[torch.fx.Node, Any] = {}
-        node_priorities: dict[torch.fx.Node, int] = {}
+        self._priority_by_node = {}
         pattern_groups: dict[torch.fx.Node, frozenset[torch.fx.Node]] = {}
         primary_nodes: set[torch.fx.Node] = set()
         for priority, (primary_node, cfg, match_info) in enumerate(
@@ -284,7 +303,7 @@ class _AnnotationHandler(TorchPT2EQuantizer):
                 if covered_node in winning_configs:
                     continue  # first (highest-priority) pattern wins
                 winning_configs[covered_node] = cfg
-                node_priorities[covered_node] = priority
+                self._priority_by_node[covered_node] = priority
                 pattern_groups[covered_node] = covered
                 if covered_node is primary_node:
                     primary_nodes.add(covered_node)
@@ -302,7 +321,7 @@ class _AnnotationHandler(TorchPT2EQuantizer):
         # settles them. See docs/architecture_notes/graph_annotation.md.
         ctx = _AnnotationContext(
             winning_configs=winning_configs,
-            node_priorities=node_priorities,
+            node_priorities=self._priority_by_node,
             pattern_groups=pattern_groups,
             primary_nodes=primary_nodes,
             shared_observer_nodes=shared_observer_node_to_pattern,
@@ -686,6 +705,10 @@ class GraphQuantizer(_BaseQuantizer):
 
         self._validate_config(config)
         super().__init__(model, config)
+        # Set by prepare() from the annotation handler's node priorities; used
+        # by _get_fake_quantize_modules() to resolve a shared FQ module's
+        # owner. Empty until prepare() has run.
+        self._node_priorities: dict[torch.fx.Node, int] = {}
 
     @staticmethod
     def _fill_input_output_specs_to_check_for_module_config(
@@ -1019,6 +1042,11 @@ class GraphQuantizer(_BaseQuantizer):
         if torchao_requires_empty_kwargs:
             restore_kwargs(prepared_model.graph, saved_kwargs)
 
+        # Carry over the node priorities computed during annotation so
+        # _get_fake_quantize_modules can later resolve a shared FQ module's
+        # owner using the same priority that decided its DTYPE field.
+        self._node_priorities = quantizer._node_priorities
+
         # Apply post-processing fixes to the prepared model
         self._postprocess_prepared_model(prepared_model)
 
@@ -1285,8 +1313,16 @@ class GraphQuantizer(_BaseQuantizer):
 
         Walks the FX graph to find FQ ``call_module`` nodes and resolves
         each one back to the original (pre-``torch.export``) module name
-        via the ``nn_module_stack`` metadata on the FQ node's consumer
-        nodes.
+        via the ``nn_module_stack`` metadata on the FQ node's neighbor
+        (consumer or producer) nodes.
+
+        When an FQ module is shared by several modules (a tied weight, or a
+        shared activation observer), the neighbors are ranked by
+        ``self._node_priorities`` — the same per-node priority that decided
+        the shared tensor's DTYPE field during annotation (see
+        ``_AnnotationHandler.annotate``) — so the resolved owner matches the
+        module whose config actually won for that tensor, rather than
+        whichever consumer happens to appear first in graph order.
 
         Returns:
             Dict mapping original module name to the list of FQ module
@@ -1295,6 +1331,8 @@ class GraphQuantizer(_BaseQuantizer):
         model = self._model
         modules = dict(model.named_modules(remove_duplicate=False))
         mapping: dict[str, list[FakeQuantizeImplBase]] = defaultdict(list)
+        node_priorities = self._node_priorities
+        unranked = len(node_priorities)
 
         for node in model.graph.nodes:
             if node.op != "call_module":
@@ -1302,11 +1340,18 @@ class GraphQuantizer(_BaseQuantizer):
             fq_mod = modules.get(node.target)
             if not isinstance(fq_mod, FakeQuantizeImplBase):
                 continue
-            # Resolve source module from the FQ node's consumer (user) nodes.
-            # Fall back to producer (arg) nodes if no consumer has nn_module_stack
-            # (e.g. when the FQ feeds directly into the graph output node).
+            # Rank neighbors by annotation priority (lower = higher precedence);
+            # neighbors with no recorded priority sort last but are still tried,
+            # preserving the original users-then-args fallback order among them.
+            neighbors = list(node.users) + list(node.args)
+            ranked_neighbors = sorted(
+                neighbors,
+                key=lambda n: (
+                    node_priorities.get(n, unranked) if isinstance(n, torch.fx.Node) else unranked
+                ),
+            )
             source = None
-            for neighbor in list(node.users) + list(node.args):
+            for neighbor in ranked_neighbors:
                 source = get_source_module_name(neighbor)
                 if source is not None:
                     break

--- a/tests/quantization/test_qat_schedule.py
+++ b/tests/quantization/test_qat_schedule.py
@@ -25,6 +25,7 @@ from coreai_opt.quantization import (
 )
 from coreai_opt.quantization.config import ExecutionMode, QATSchedule
 from coreai_opt.quantization.spec import (
+    QuantizationSpec,
     default_activation_quantization_spec,
     default_weight_quantization_spec,
 )
@@ -167,12 +168,17 @@ class SharedWeightModel(nn.Module):
 
 
 @pytest.mark.parametrize("execution_mode", [ExecutionMode.EAGER, ExecutionMode.GRAPH])
-def test_shared_weight_keeps_first_schedule(execution_mode):
-    """When two modules share a weight, the shared FQ gets the first
-    module's schedule. In Eager mode a warning is emitted because the
-    same FQ instance is found under both modules. In PT2E the graph
-    deduplicates the shared weight into a single FQ node so no
-    conflict arises.
+def test_shared_weight_schedule_owner(execution_mode):
+    """When two modules share a weight, the shared FQ's schedule follows a
+    single, consistent owner rather than an arbitrary mix of both configs.
+
+    In Eager mode the same FakeQuantize instance is literally shared between
+    both modules, so a warning is emitted and the first-assigned schedule
+    (linear1's) wins. In graph mode the shared weight is deduplicated into
+    one FQ node whose owning module is resolved by config priority — the
+    same priority that decides the FQ's dtype (see
+    ``GraphQuantizer._get_fake_quantize_modules``) — which for two
+    ``module_name_configs`` entries is the later-declared one (linear2's).
     """
     config = QuantizerConfig(
         global_config=None,
@@ -205,14 +211,58 @@ def test_shared_weight_keeps_first_schedule(execution_mode):
 
     assert len(quantizer._fq_to_schedule) == 1
     (schedule,) = quantizer._fq_to_schedule.values()
-    assert schedule.enable_fake_quant == 1
+    # Eager mode picks linear1's schedule (first-assigned to the shared FQ
+    # instance); graph mode picks linear2's, since it has higher config
+    # priority (declared later) — the same priority that decides dtype.
+    expected_step = 1 if execution_mode == ExecutionMode.EAGER else 5
+    assert schedule.enable_fake_quant == expected_step
 
-    # Verify linear1's schedule (fq at step 1) is actually applied
+    # Verify the winning owner's schedule is actually applied
     with quantizer.training_mode():
         (fq_mod,) = quantizer._fq_to_schedule.keys()
         assert fq_mod.fake_quant_enabled.item() == 0
-        quantizer.step()  # step_count = 1
+        for _ in range(expected_step):
+            quantizer.step()
         assert fq_mod.fake_quant_enabled.item() == 1
+
+
+def test_shared_weight_dtype_and_schedule_share_owner_graph_mode():
+    """In graph mode, a shared weight's QATSchedule follows the same config
+    priority used to resolve its dtype and the rest of its qspec.
+
+    linear2 has higher priority than linear1 since it is declared later in
+    ``module_name_configs``, so the shared FQ's dtype, qspec, and
+    QATSchedule should all follow linear2's config — even though linear1 is
+    the first consumer encountered in graph order.
+    """
+    config = QuantizerConfig(
+        global_config=None,
+        module_name_configs={
+            "linear1": ModuleQuantizerConfig(
+                op_state_spec={"weight": QuantizationSpec(dtype=torch.int8)},
+                op_input_spec=None,
+                op_output_spec=None,
+                qat_schedule=QATSchedule(enable_observer=0, enable_fake_quant=1),
+            ),
+            "linear2": ModuleQuantizerConfig(
+                op_state_spec={"weight": QuantizationSpec(dtype=torch.int4)},
+                op_input_spec=None,
+                op_output_spec=None,
+                qat_schedule=QATSchedule(enable_observer=0, enable_fake_quant=5),
+            ),
+        },
+        execution_mode=ExecutionMode.GRAPH,
+    )
+    quantizer = Quantizer(SharedWeightModel(), config)
+    quantizer.prepare((torch.randn(1, 10),))
+
+    assert len(quantizer._fq_to_schedule) == 1
+    (fq_mod, schedule) = next(iter(quantizer._fq_to_schedule.items()))
+
+    # linear2 (declared later, higher config priority) owns the dtype ...
+    assert (fq_mod.quant_min, fq_mod.quant_max) == (-8, 7)  # int4
+    # ... and must also own the schedule.
+    assert schedule.enable_fake_quant == 5
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Fixes #41: a tied weight's fake-quantize module could quantize with one
  module's dtype while following a different module's QAT schedule, since
  the two were resolved by independent orderings (graph order vs. config
  priority).
- `_get_fake_quantize_modules` now ranks a shared FQ's candidate owning
  modules by the same annotation priority used to reconcile its DTYPE
  field, so both resolve to one consistent owner.

## Test plan
- [x] Reproduced the exact scenario from #41 and confirmed dtype/schedule
      now agree on the same module
- [x] `tests/quantization/test_qat_schedule.py` — updated existing
      `test_shared_weight_schedule_owner` for the corrected graph-mode
      behavior, added `test_shared_weight_dtype_and_schedule_share_owner_graph_mode`
      as a regression test for the exact dtype+schedule conflict
- [x] `make check` passes
- [x] `make test` passes
