### PR TITLE
fix indent in `spec.py` for error in docs generation

### DIFF
--- a/src/coreai_opt/quantization/spec/spec.py
+++ b/src/coreai_opt/quantization/spec/spec.py
@@ -65,7 +65,8 @@ class QuantizationSpec(CompressionSpec):
             Quantization scheme determining how values are mapped to the quantized
             range.
             Valid inputs:
-             - "symmetric" (default), "symmetric_with_clipping", "asymmetric"
+
+            - "symmetric" (default), "symmetric_with_clipping", "asymmetric"
 
             On how it affects the quantization and dequantization formulae,
             please refer to the `qformulation` description below.


### PR DESCRIPTION
Fixes this error during docs generation:

```sh
src/coreai_opt/quantization/spec/spec.py:docstring of coreai_opt.quantization.spec.spec.QuantizationSpec:32: ERROR: Unexpected indentation. [docutils]
```