### PR TITLE
Re-cluster palettization centroids from the warmed-up weights when a PATSchedule enables fake palettization mid-training

### DIFF
--- a/changelog.d/180525445.fixed
+++ b/changelog.d/180525445.fixed
@@ -1,1 +1,0 @@
-Fix setting of qscheme and float_range for fixed output range ops

--- a/changelog.d/22.fixed
+++ b/changelog.d/22.fixed
@@ -1,0 +1,1 @@
+Fix setting of qscheme and float_range for fixed output range ops.

--- a/changelog.d/86.changed
+++ b/changelog.d/86.changed
@@ -1,0 +1,1 @@
+Re-cluster palettization centroids from the warmed-up weights when a `PATSchedule` enables fake palettization mid-training (`enable_fake_palettize > 0`).

--- a/src/coreai_opt/palettization/kmeans/kmeans_fake_palettize.py
+++ b/src/coreai_opt/palettization/kmeans/kmeans_fake_palettize.py
@@ -155,6 +155,11 @@ class _KMeansFakePalettize(_FakePalettizeImplBase):
         self._centroids_initialized = False
         self._indices_stale = True
 
+    def _invalidate(self) -> None:
+        """Invalidate centroids so the next forward re-clusters from the current weights."""
+        self._centroids_initialized = False
+        self._indices_stale = True
+
     def ensure_initialized(self, tensor: torch.Tensor) -> None:
         """Cluster centroids on first use; disable on an incompatible tensor.
 

--- a/src/coreai_opt/palettization/kmeans/palettizer.py
+++ b/src/coreai_opt/palettization/kmeans/palettizer.py
@@ -394,7 +394,12 @@ class KMeansPalettizer(_BasePalettizer, _EagerCompressionComponentBuilderMixin):
 
     def _apply_schedule(self) -> None:
         for fp_module, schedule in self._fp_to_schedule.items():
-            fp_module.enable_fake_palett(schedule._compute_state(self._step_count))
+            new_state = schedule._compute_state(self._step_count)
+            # On the warm-up -> enabled transition, re-cluster from the current
+            # (warmed-up) weights instead of the frozen prepare-time centroids.
+            if new_state and not fp_module.fake_palett_enabled[0]:
+                fp_module._centroids_initialized = False
+            fp_module.enable_fake_palett(new_state)
 
     def _validate_mmap_dir_constraints(
         self,

--- a/src/coreai_opt/palettization/kmeans/palettizer.py
+++ b/src/coreai_opt/palettization/kmeans/palettizer.py
@@ -397,8 +397,7 @@ class KMeansPalettizer(_BasePalettizer, _EagerCompressionComponentBuilderMixin):
             new_state = schedule._compute_state(self._step_count)
             # On the warm-up -> enabled transition, re-cluster from the current
             # (warmed-up) weights instead of the frozen prepare-time centroids.
-            reinitialize = new_state and not fp_module.fake_palett_enabled[0]
-            fp_module.enable_fake_palett(new_state, reinitialize=reinitialize)
+            fp_module.enable_fake_palett(new_state, reinitialize=new_state)
 
     def _validate_mmap_dir_constraints(
         self,

--- a/src/coreai_opt/palettization/kmeans/palettizer.py
+++ b/src/coreai_opt/palettization/kmeans/palettizer.py
@@ -397,9 +397,8 @@ class KMeansPalettizer(_BasePalettizer, _EagerCompressionComponentBuilderMixin):
             new_state = schedule._compute_state(self._step_count)
             # On the warm-up -> enabled transition, re-cluster from the current
             # (warmed-up) weights instead of the frozen prepare-time centroids.
-            if new_state and not fp_module.fake_palett_enabled[0]:
-                fp_module._centroids_initialized = False
-            fp_module.enable_fake_palett(new_state)
+            reinitialize = new_state and not fp_module.fake_palett_enabled[0]
+            fp_module.enable_fake_palett(new_state, reinitialize=reinitialize)
 
     def _validate_mmap_dir_constraints(
         self,

--- a/src/coreai_opt/palettization/spec/fake_palettize.py
+++ b/src/coreai_opt/palettization/spec/fake_palettize.py
@@ -194,17 +194,19 @@ class _FakePalettizeImplBase(CompressionSimulatorBase, nn.Module):
 
         Args:
             enabled (bool): Whether the forward pass palettizes the tensor.
-            reinitialize (bool): When enabling, invalidate cached compression
-                params so the next forward re-derives them from the current
-                weights. Only valid when ``enabled`` is True.
+            reinitialize (bool): On a disabled -> enabled switch, invalidate cached
+                compression params so the next forward re-derives them from the
+                current weights. Ignored when the module is already enabled. Only
+                valid when ``enabled`` is True.
 
         Raises:
             ValueError: If ``reinitialize`` is True while ``enabled`` is False.
         """
         if reinitialize and not enabled:
             raise ValueError("reinitialize=True requires enabled=True.")
+        was_enabled = bool(self.fake_palett_enabled[0])
         self.fake_palett_enabled[0] = 1 if enabled else 0
-        if reinitialize:
+        if reinitialize and not was_enabled:
             self._invalidate()
 
     def disable_fake_palett(self):

--- a/src/coreai_opt/palettization/spec/fake_palettize.py
+++ b/src/coreai_opt/palettization/spec/fake_palettize.py
@@ -189,11 +189,34 @@ class _FakePalettizeImplBase(CompressionSimulatorBase, nn.Module):
             if prefixed_key in unexpected_keys:
                 unexpected_keys.remove(prefixed_key)
 
-    def enable_fake_palett(self, enabled: bool = True) -> None:
+    def enable_fake_palett(self, enabled: bool = True, reinitialize: bool = False) -> None:
+        """Enable or disable fake palettization in the forward pass.
+
+        Args:
+            enabled (bool): Whether the forward pass palettizes the tensor.
+            reinitialize (bool): When enabling, invalidate cached compression
+                params so the next forward re-derives them from the current
+                weights. Only valid when ``enabled`` is True.
+
+        Raises:
+            ValueError: If ``reinitialize`` is True while ``enabled`` is False.
+        """
+        if reinitialize and not enabled:
+            raise ValueError("reinitialize=True requires enabled=True.")
         self.fake_palett_enabled[0] = 1 if enabled else 0
+        if reinitialize:
+            self._invalidate()
 
     def disable_fake_palett(self):
+        """Disable fake palettization in the forward pass."""
         self.enable_fake_palett(False)
+
+    @abstractmethod
+    def _invalidate(self) -> None:
+        """Invalidate cached compression params so the next forward re-derives
+        them from the current weights.
+        """
+        raise NotImplementedError()
 
 
 def _enable_fake_palett(mod):

--- a/tests/palettization/test_kmeans_fake_palettize.py
+++ b/tests/palettization/test_kmeans_fake_palettize.py
@@ -1876,6 +1876,51 @@ class TestLazyInitAndStaleness:
         assert target._indices_stale is True
 
 
+class TestReinitializeOnEnable:
+    """enable_fake_palett(reinitialize=True) invalidates cached params so the
+    next forward re-clusters from the current weights.
+    """
+
+    @staticmethod
+    def _make() -> _KMeansFakePalettize:
+        spec = PalettizationSpec(n_bits=2, granularity=PerTensorGranularity())
+        return _KMeansFakePalettize(**spec.__dict__)
+
+    def test_reinitialize_invalidates_and_reclusters(self):
+        palettizer = self._make()
+        palettizer(torch.tensor([-1.0, 1.0]).repeat(4, 4))
+        assert palettizer._centroids_initialized is True
+        centroids_before = palettizer.centroids.clone()
+
+        palettizer.enable_fake_palett(True, reinitialize=True)
+        assert palettizer._centroids_initialized is False
+        assert palettizer._indices_stale is True
+
+        # Next forward re-clusters from the new weights, not the old centroids.
+        palettizer(torch.tensor([-4.0, 4.0]).repeat(4, 4))
+        assert palettizer._centroids_initialized is True
+        assert not torch.equal(palettizer.centroids, centroids_before)
+
+    def test_default_keeps_centroids(self):
+        palettizer = self._make()
+        palettizer(torch.randn(8, 8))
+        centroids_before = palettizer.centroids.clone()
+
+        palettizer.enable_fake_palett(True)  # reinitialize defaults False
+        assert palettizer._centroids_initialized is True
+        # A forward pass with different weights does not affect centroids
+        palettizer(torch.randn(8, 8))
+        assert torch.equal(palettizer.centroids, centroids_before)
+
+    def test_reinitialize_requires_enabled(self):
+        palettizer = self._make()
+        palettizer(torch.randn(8, 8))
+
+        with pytest.raises(ValueError, match="reinitialize=True requires enabled=True"):
+            palettizer.enable_fake_palett(False, reinitialize=True)
+        assert palettizer._centroids_initialized is True
+
+
 class TestQuantizeLutSTE:
     """quantize_lut() fake-quantizes the LUT through a straight-through estimator."""
 

--- a/tests/palettization/test_kmeans_fake_palettize.py
+++ b/tests/palettization/test_kmeans_fake_palettize.py
@@ -1877,8 +1877,9 @@ class TestLazyInitAndStaleness:
 
 
 class TestReinitializeOnEnable:
-    """enable_fake_palett(reinitialize=True) invalidates cached params so the
-    next forward re-clusters from the current weights.
+    """enable_fake_palett(reinitialize=True) invalidates cached params on a
+    disabled -> enabled switch so the next forward re-clusters from the current
+    weights.
     """
 
     @staticmethod
@@ -1892,6 +1893,7 @@ class TestReinitializeOnEnable:
         assert palettizer._centroids_initialized is True
         centroids_before = palettizer.centroids.clone()
 
+        palettizer.disable_fake_palett()
         palettizer.enable_fake_palett(True, reinitialize=True)
         assert palettizer._centroids_initialized is False
         assert palettizer._indices_stale is True
@@ -1901,11 +1903,24 @@ class TestReinitializeOnEnable:
         assert palettizer._centroids_initialized is True
         assert not torch.equal(palettizer.centroids, centroids_before)
 
+    def test_reinitialize_noop_when_already_enabled(self):
+        palettizer = self._make()
+        palettizer(torch.randn(8, 8))
+        assert palettizer.fake_palett_enabled[0] == 1
+        centroids_before = palettizer.centroids.clone()
+
+        # Already enabled: reinitialize is ignored, centroids survive.
+        palettizer.enable_fake_palett(True, reinitialize=True)
+        assert palettizer._centroids_initialized is True
+        palettizer(torch.randn(8, 8))
+        assert torch.equal(palettizer.centroids, centroids_before)
+
     def test_default_keeps_centroids(self):
         palettizer = self._make()
         palettizer(torch.randn(8, 8))
         centroids_before = palettizer.centroids.clone()
 
+        palettizer.disable_fake_palett()
         palettizer.enable_fake_palett(True)  # reinitialize defaults False
         assert palettizer._centroids_initialized is True
         # A forward pass with different weights does not affect centroids

--- a/tests/palettization/test_pat_schedule.py
+++ b/tests/palettization/test_pat_schedule.py
@@ -27,7 +27,11 @@ from coreai_opt.palettization import (
 )
 from coreai_opt.palettization.config import PATSchedule
 from coreai_opt.palettization.kmeans.kmeans_fake_palettize import _KMeansFakePalettize
-from coreai_opt.palettization.spec import default_weight_palettization_spec
+from coreai_opt.palettization.spec import (
+    PalettizationSpec,
+    PerTensorGranularity,
+    default_weight_palettization_spec,
+)
 
 
 class ToyModel(nn.Module):
@@ -348,3 +352,48 @@ class TestDefaultStrategyTraining:
         # graph intact: gradients reach the input (through the palettized layer) and downstream
         assert x.grad is not None
         assert prepared.head.weight.grad is not None
+
+
+class TestReclusterOnScheduleEnable:
+    """Crossing the enable_fake_palettize threshold after warm-up re-clusters
+    centroids from the current (warmed-up) weights, not the frozen prepare-time
+    weights.
+    """
+
+    def test_reclusters_from_warmed_up_weights(self):
+        spec = PalettizationSpec(
+            n_bits=2,
+            lut_qspec=None,
+            granularity=PerTensorGranularity(),
+            cluster_dim=1,
+            enable_per_channel_scale=False,
+        )
+        config = KMeansPalettizerConfig(
+            global_config=ModuleKMeansPalettizerConfig(
+                op_state_spec={"weight": spec},
+                pat_schedule=PATSchedule(enable_fake_palettize=2),
+            )
+        )
+        palettizer = KMeansPalettizer(ToyModel(), config)
+        prepared = palettizer.prepare(_example_input())
+        fp = _fp_for(prepared, "linear")
+        prepare_centroids = fp.centroids.clone()
+
+        # warmed_up represents weights that have updated as a result of training during warmup
+        warmed_up = torch.tensor([-3.0, -1.0, 1.0, 3.0]).repeat(32).reshape(8, 16)
+        with palettizer.training_mode():
+            with torch.no_grad():
+                prepared.linear.parametrizations.weight.original.copy_(warmed_up)
+            palettizer.step()  # step 1 < 2: still disabled (warm-up)
+            palettizer.step()  # step 2 == threshold: disabled -> enabled transition
+            reconstructed = prepared.linear.weight  # triggers the re-cluster + hard assign
+
+        # Centroids were recomputed from the warmed-up weights, not frozen at prepare time.
+        assert not torch.equal(fp.centroids, prepare_centroids)
+        torch.testing.assert_close(
+            fp.centroids.flatten().sort().values,
+            torch.tensor([-3.0, -1.0, 1.0, 3.0]),
+        )
+        # Exact reconstruction is only possible if the centroids came from the
+        # warmed-up weights.
+        torch.testing.assert_close(reconstructed, warmed_up)


### PR DESCRIPTION
Currently if enable_fake_palettize > 0 in PATSchedule, centroids are initialized at the start and reused when the module is later enabled via PATSchedule and palettizer.step(). Instead, recompute centroids based on trained updated weights that changed during step < enable_fake_palettize.